### PR TITLE
BREAKING CHANGE: Reworked image upload, using IFormFile instead of byte arrays

### DIFF
--- a/src/Eurofurence.App.Domain.Model/Knowledge/KnowledgeEntryRecord.cs
+++ b/src/Eurofurence.App.Domain.Model/Knowledge/KnowledgeEntryRecord.cs
@@ -27,9 +27,9 @@ namespace Eurofurence.App.Domain.Model.Knowledge
         public int Order { get; set; }
 
         [DataMember] 
-        public List<LinkFragment> Links { get; set; } = new();
+        public virtual List<LinkFragment> Links { get; set; } = new();
 
         [DataMember]
-        public List<ImageRecord> Images { get; set; }
+        public virtual List<ImageRecord> Images { get; set; } = new();
     }
 }

--- a/src/Eurofurence.App.Server.Services/Abstractions/ArtistsAlley/TableRegistrationRequest.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/ArtistsAlley/TableRegistrationRequest.cs
@@ -1,4 +1,6 @@
-﻿namespace Eurofurence.App.Server.Services.Abstractions.ArtistsAlley
+﻿using System;
+
+namespace Eurofurence.App.Server.Services.Abstractions.ArtistsAlley
 {
     public class TableRegistrationRequest
     {
@@ -8,7 +10,7 @@
 
         public string ShortDescription { get; set; }
 
-        public string ImageContent { get; set; }
+        public Guid ImageId { get; set; }
 
         public string Location { get; set; }
 

--- a/src/Eurofurence.App.Server.Services/Abstractions/Fursuits/FursuitBadgeRegistration.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/Fursuits/FursuitBadgeRegistration.cs
@@ -1,4 +1,6 @@
-﻿namespace Eurofurence.App.Server.Services.Abstractions.Fursuits
+﻿using System;
+
+namespace Eurofurence.App.Server.Services.Abstractions.Fursuits
 {
     public class FursuitBadgeRegistration
     {
@@ -8,7 +10,7 @@
         public string WornBy { get; set; }
         public string Species { get; set; }
         public string Gender { get; set; }
-        public string ImageContent { get; set; }
+        public Guid ImageId { get; set; }
         public int DontPublish { get; set; }
         public string CollectionCode { get; set; }
     }

--- a/src/Eurofurence.App.Server.Services/Abstractions/Fursuits/IFursuitBadgeService.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/Fursuits/IFursuitBadgeService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Eurofurence.App.Domain.Model.Fursuits;
@@ -9,7 +10,7 @@ namespace Eurofurence.App.Server.Services.Abstractions.Fursuits
     {
         Task<Guid> UpsertFursuitBadgeAsync(FursuitBadgeRegistration registration);
 
-        Task<byte[]> GetFursuitBadgeImageAsync(Guid id);
+        Task<Stream> GetFursuitBadgeImageAsync(Guid id);
 
         IQueryable<FursuitBadgeRecord> GetFursuitBadges(FursuitBadgeFilter filter = null);
     }

--- a/src/Eurofurence.App.Server.Services/Abstractions/Images/IImageService.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/Images/IImageService.cs
@@ -1,16 +1,16 @@
 ﻿using System;
+using System.IO;
 using System.Threading.Tasks;
-using Eurofurence.App.Domain.Model.Fragments;
 using Eurofurence.App.Domain.Model.Images;
 
 namespace Eurofurence.App.Server.Services.Abstractions.Images
 {
     public interface IImageService : IEntityServiceOperations<ImageRecord>
     {
-        Task InsertImageAsync(ImageRecord image, byte[] imageBytes);
-        Task<ImageRecord> InsertOrUpdateImageAsync(string internalReference, byte[] imageBytes);
-        Task<byte[]> GetImageContentByImageIdAsync(Guid id);
-        byte[] GeneratePlaceholderImage();
+        Task<ImageRecord> InsertImageAsync(string internalReference, Stream stream);
+        Task<ImageRecord> ReplaceImageAsync(Guid id, string internalReference, Stream stream);
+        Task<Stream> GetImageContentByImageIdAsync(Guid id);
+        Stream GeneratePlaceholderImage();
         Task<ImageRecord> EnforceMaximumDimensionsAsync(ImageRecord image, int width, int height);
     }
 }

--- a/src/Eurofurence.App.Server.Services/Abstractions/Knowledge/IKnowledgeEntryService.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/Knowledge/IKnowledgeEntryService.cs
@@ -1,4 +1,6 @@
 ﻿using Eurofurence.App.Domain.Model.Knowledge;
+using System;
+using System.Threading.Tasks;
 
 namespace Eurofurence.App.Server.Services.Abstractions.Knowledge
 {
@@ -6,5 +8,8 @@ namespace Eurofurence.App.Server.Services.Abstractions.Knowledge
         IEntityServiceOperations<KnowledgeEntryRecord>,
         IPatchOperationProcessor<KnowledgeEntryRecord>
     {
+        public Task<KnowledgeEntryRecord> InsertKnowledgeEntryAsync(KnowledgeEntryRequest request);
+
+        public Task<KnowledgeEntryRecord> ReplaceKnowledgeEntryAsync(Guid id, KnowledgeEntryRequest request);
     }
 }

--- a/src/Eurofurence.App.Server.Services/Abstractions/Knowledge/KnowledgeEntryRequest.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/Knowledge/KnowledgeEntryRequest.cs
@@ -1,0 +1,21 @@
+﻿using Eurofurence.App.Domain.Model.Fragments;
+using System.Collections.Generic;
+using System;
+
+namespace Eurofurence.App.Server.Services.Abstractions.Knowledge
+{
+    public class KnowledgeEntryRequest
+    {
+        public Guid KnowledgeGroupId { get; set; }
+
+        public string Title { get; set; }
+
+        public string Text { get; set; }
+
+        public int Order { get; set; }
+
+        public List<LinkFragment> Links { get; set; } = new();
+
+        public List<Guid> ImageIds { get; set; } = new();
+    }
+}

--- a/src/Eurofurence.App.Server.Services/Knowledge/KnowledgeEntryService.cs
+++ b/src/Eurofurence.App.Server.Services/Knowledge/KnowledgeEntryService.cs
@@ -1,4 +1,7 @@
-﻿using Eurofurence.App.Domain.Model.Knowledge;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Eurofurence.App.Domain.Model.Knowledge;
 using Eurofurence.App.Infrastructure.EntityFramework;
 using Eurofurence.App.Server.Services.Abstractions;
 using Eurofurence.App.Server.Services.Abstractions.Knowledge;
@@ -8,12 +11,74 @@ namespace Eurofurence.App.Server.Services.Knowledge
     public class KnowledgeEntryService : EntityServiceBase<KnowledgeEntryRecord>,
         IKnowledgeEntryService
     {
+        private readonly AppDbContext _appDbContext;
+        private readonly IStorageService _storageService;
+
         public KnowledgeEntryService(
             AppDbContext appDbContext,
             IStorageServiceFactory storageServiceFactory
         )
             : base(appDbContext, storageServiceFactory)
         {
+            _appDbContext = appDbContext;
+            _storageService = storageServiceFactory.CreateStorageService<KnowledgeEntryRecord>();
+        }
+        public override Task ReplaceOneAsync(KnowledgeEntryRecord entity)
+        {
+            throw new InvalidOperationException();
+        }
+
+        public override Task InsertOneAsync(KnowledgeEntryRecord entity)
+        {
+            throw new InvalidOperationException();
+        }
+
+        public async Task<KnowledgeEntryRecord> InsertKnowledgeEntryAsync(KnowledgeEntryRequest request)
+        {
+            var images = _appDbContext.Images.Where(image => request.ImageIds.Contains(image.Id));
+
+            var entity = new KnowledgeEntryRecord
+            {
+                KnowledgeGroupId = request.KnowledgeGroupId,
+                Title = request.Title,
+                Text = request.Text,
+                Order = request.Order,
+                Links = request.Links,
+                IsDeleted = 0
+            };
+
+            entity.Images.AddRange(images);
+
+            entity.Touch();
+            var result = await _appDbContext.AddAsync(entity);
+            await _storageService.TouchAsync();
+            await _appDbContext.SaveChangesAsync();
+            return result.Entity;
+        }
+
+        public async Task<KnowledgeEntryRecord> ReplaceKnowledgeEntryAsync(Guid id, KnowledgeEntryRequest request)
+        {
+            var images = _appDbContext.Images.Where(image => request.ImageIds.Contains(image.Id));
+
+            var entity = new KnowledgeEntryRecord
+            {
+                Id = id,
+                KnowledgeGroupId = request.KnowledgeGroupId,
+                Title = request.Title,
+                Text = request.Text,
+                Order = request.Order,
+                Links = request.Links,
+                IsDeleted = 0
+            };
+
+            entity.Images = [.. images];
+
+            entity.Touch();
+            var result = _appDbContext.KnowledgeEntries.Update(entity);
+            await _storageService.TouchAsync();
+            await _appDbContext.SaveChangesAsync();
+
+            return result.Entity;
         }
     }
 }

--- a/src/Eurofurence.App.Server.Web/Jobs/UpdateNewsJob.cs
+++ b/src/Eurofurence.App.Server.Web/Jobs/UpdateNewsJob.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
@@ -144,7 +145,8 @@ namespace Eurofurence.App.Server.Web.Jobs
             if (string.IsNullOrWhiteSpace(imageDataBase64)) return null;
             var imageBytes = Convert.FromBase64String(imageDataBase64);
 
-            var image = await _imageService.InsertOrUpdateImageAsync(reference, imageBytes);
+            using MemoryStream ms = new(imageBytes);
+            var image = await _imageService.InsertImageAsync(reference, ms);
             return image.Id;
         }
     }

--- a/src/Eurofurence.App.Tools.CliToolBox/Commands/DealersCommand.cs
+++ b/src/Eurofurence.App.Tools.CliToolBox/Commands/DealersCommand.cs
@@ -95,7 +95,7 @@ namespace Eurofurence.App.Tools.CliToolBox.Commands
 
                 foreach(var image in unusedImages)
                 {
-                    Console.WriteLine($"  Removing {image.Id} ({image.InternalReference})");
+                    Console.WriteLine($"  Removing {image.Id}");
                     _imageService.DeleteOneAsync(image.Id).Wait();
                 }
 

--- a/src/Eurofurence.App.Tools.CliToolBox/Commands/KnowledgeCommand.cs
+++ b/src/Eurofurence.App.Tools.CliToolBox/Commands/KnowledgeCommand.cs
@@ -124,11 +124,11 @@ namespace Eurofurence.App.Tools.CliToolBox.Commands
                 var archive = ZipFile.Open(inputPathArgument.Value, ZipArchiveMode.Read);
 
                 var knowledgeGroups = archive.ReadAsJson<IEnumerable<KnowledgeGroupRecord>>("knowledgeGroups");
-                var knowledgeEntries = archive.ReadAsJson<IEnumerable<KnowledgeEntryRecord>>("knowledgeEntries");
+                var knowledgeEntries = archive.ReadAsJson<IEnumerable<KnowledgeEntryRequest>>("knowledgeEntries");
                 var images = archive.ReadAsJson<IEnumerable<ImageRecord>>("images");
 
                 foreach (var entity in knowledgeGroups) _knowledgeGroupService.InsertOneAsync(entity).Wait();
-                foreach (var entity in knowledgeEntries) _knowledgeEntryService.InsertOneAsync(entity).Wait();
+                foreach (var entity in knowledgeEntries) _knowledgeEntryService.InsertKnowledgeEntryAsync(entity).Wait();
                 foreach (var entity in images)
                 {
                     var imageData = archive.ReadAsBinary($"imageContent-{entity.Id}");

--- a/src/Eurofurence.App.Tools.CliToolBox/Commands/MapCommand.cs
+++ b/src/Eurofurence.App.Tools.CliToolBox/Commands/MapCommand.cs
@@ -135,12 +135,9 @@ namespace Eurofurence.App.Tools.CliToolBox.Commands
                 var map = _mapService.FindOneAsync(Guid.Parse(idOption.Value())).Result;
                 var image = File.Open(imagePathOption.Value(), FileMode.Open, FileAccess.Read);
 
-                var buffer = new byte[image.Length];
-                image.Read(buffer, 0, (int) image.Length);
-
                 Console.WriteLine($"Updating map image {map.Id} ({map.Description}) from {imagePathOption.Value()}...");
 
-                var imageRecord = _imageService.InsertOrUpdateImageAsync($"map:{map.Id}", buffer).Result;
+                var imageRecord = _imageService.InsertImageAsync($"map:{map.Id}", image).Result;
                 Console.WriteLine(
                     $"Image record {imageRecord.Id} has hash={imageRecord.ContentHashSha1}, last changed at {imageRecord.LastChangeDateTimeUtc} UTC");
 

--- a/src/Eurofurence.App.Tools.CliToolBox/Commands/StorageCommand.cs
+++ b/src/Eurofurence.App.Tools.CliToolBox/Commands/StorageCommand.cs
@@ -77,7 +77,7 @@ namespace Eurofurence.App.Tools.CliToolBox.Commands
                 var unusedImages = GetUnusedImagesAsync().Result;
 
                 unusedImages.ToList().ForEach(a =>
-                    command.Out.WriteLine($"{a.Id} ({a.InternalReference}), {a.Width}x{a.Height} px, {a.SizeInBytes} bytes"));
+                    command.Out.WriteLine($"{a.Id}, {a.Width}x{a.Height} px, {a.SizeInBytes} bytes"));
 
                 return 0;
             });

--- a/src/Eurofurence.App.Tools.CliToolBox/Importers/DealersDen/PackageImporter.cs
+++ b/src/Eurofurence.App.Tools.CliToolBox/Importers/DealersDen/PackageImporter.cs
@@ -182,16 +182,11 @@ namespace Eurofurence.App.Tools.CliToolBox.Importers.DealersDen
                 archive.Entries.SingleOrDefault(
                     a => a.Name.StartsWith(fileNameStartsWith, StringComparison.CurrentCultureIgnoreCase));
 
-            if (imageEntry != null)
-                using (var s = imageEntry.Open())
-                using (var br = new BinaryReader(s))
-                {
-                    var imageByteArray = br.ReadBytes((int) imageEntry.Length);
-                    var result = await _imageService.InsertOrUpdateImageAsync(internalReference, imageByteArray);
-                    return result.Id;
-                }
+            if (imageEntry == null) return null;
 
-            return null;
+            await using var s = imageEntry.Open();
+            var result = await _imageService.InsertImageAsync(internalReference, s);
+            return result?.Id;
         }
     }
 

--- a/src/Eurofurence.App.Tools.CliToolBox/Importers/EventSchedule/ImageImporter.cs
+++ b/src/Eurofurence.App.Tools.CliToolBox/Importers/EventSchedule/ImageImporter.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Eurofurence.App.Server.Services.Abstractions.Events;
 using Eurofurence.App.Server.Services.Abstractions.Images;
+using SixLabors.ImageSharp.Drawing;
 
 namespace Eurofurence.App.Tools.CliToolBox.Importers.EventSchedule
 {
@@ -34,18 +35,21 @@ namespace Eurofurence.App.Tools.CliToolBox.Importers.EventSchedule
 
             var imageTag = $"event:{imagePurpose}:{eventId}";
 
-            var imageContent = await File.ReadAllBytesAsync(imagePath);
-            var image = await _imageService.InsertOrUpdateImageAsync(imageTag, imageContent);
-
-            switch (imagePurpose)
+            using (FileStream fileStream = File.Create(imagePath))
             {
-                    case PurposeEnum.Banner:
-                        @event.BannerImageId = image.Id;
-                        break;
-                    case PurposeEnum.Poster:
-                        @event.PosterImageId = image.Id;
-                        break;
+                var image = await _imageService.InsertImageAsync(imageTag, fileStream);
+            
+                switch (imagePurpose)
+                {
+                        case PurposeEnum.Banner:
+                            @event.BannerImageId = image.Id;
+                            break;
+                        case PurposeEnum.Poster:
+                            @event.PosterImageId = image.Id;
+                            break;
+                }
             }
+
             @event.Touch();
 
             await _eventService.ReplaceOneAsync(@event);

--- a/src/Eurofurence.App.Tools.CliToolBox/Importers/Knowledge/WikIFileImporter.cs
+++ b/src/Eurofurence.App.Tools.CliToolBox/Importers/Knowledge/WikIFileImporter.cs
@@ -134,8 +134,9 @@ namespace Eurofurence.App.Tools.CliToolBox.Importers.Knowledge
                     try
                     {
                         var imageBytes = await GetImageAsync(target);
+                        using var ms = new MemoryStream(imageBytes);
                         var image =
-                            await _imageService.InsertOrUpdateImageAsync($"knowledge:{url.AsHashToGuid()}", imageBytes);
+                            await _imageService.InsertImageAsync($"knowledge:{url.AsHashToGuid()}", ms);
 
                         images.Add(image);
                     }


### PR DESCRIPTION
I replaced the old API endpoint which took a byte array as string and replaced it by two API endpoints. A Post endpoint which takes a IFormFile as input and therefore allows file uploads, and a Put endpoint which allows replacing a file with the same id.

**BREAKING CHANGE**: I also changed the fursuit badge registration: Instead of passing a byte array with the image data, an image id is passed. So adding a fursuit badge registration is now a two-step process with first uploading the image using the image endpoint and then passing the image id.

Before: 
```
{
  "BadgeNo": 6,
  "RegNo": 6,
  "Name": "Meta",
  "WornBy": "Meta",
  "Species": "Protogen",
  "Gender": "male",
  "ImageContent ": "longByteArrayWithImageData",
  "DontPublish": 0,
  "CollectionCode": "123"
}
```

After:

```
{
  "BadgeNo": 6,
  "RegNo": 6,
  "Name": "Meta",
  "WornBy": "Meta",
  "Species": "Protogen",
  "Gender": "male",
  "ImageId": "10e3fbf7-7703-4b82-b960-931b54c000f2",
  "DontPublish": 0,
  "CollectionCode": "123"
}
```