### PR TITLE
feat(compose): add minio container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-version: '3.1'
+version: '3.8'
 services:
   backend:
-    image: ghcr.io/eurofurence/ef-app_backend-dotnet-core:dev
+    image: ghcr.io/eurofurence/ef-app_backend-dotnet-core:nightly
     build:
       context: .
       dockerfile: Dockerfile
@@ -13,6 +13,11 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      minio:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+
   db:
     image: docker.io/mariadb:latest
     environment:
@@ -26,5 +31,41 @@ services:
       interval: 5s
       timeout: 5s
       retries: 30
+
+  minio:
+    image: minio/minio
+    ports:
+      - "9000:9000"
+    volumes:
+      - minio:/data
+    environment:
+      - "MINIO_ACCESS_KEY=minioAccessKey"
+      - "MINIO_SECRET_KEY=minioVerySecretKey"
+    command: server /data
+    healthcheck:
+      test: >
+        /bin/sh -c "
+        /usr/bin/mc config host add ef-minio http://minio:9000 minioAccessKey minioVerySecretKey;
+        /usr/bin/mc ready ef-minio;
+        "
+      start_period: 5s
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  minio-init:
+    image: minio/mc
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc config host add ef-minio http://minio:9000 minioAccessKey minioVerySecretKey;
+      /usr/bin/mc ready ef-minio;
+      /usr/bin/mc mb -p ef-minio/ef-mobile-app-local;
+      /usr/bin/mc anonymous set download ef-minio/ef-mobile-app-local;
+      exit 0;
+      "
 volumes:
   db:
+  minio:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,8 @@ services:
     volumes:
       - minio:/data
     environment:
-      - "MINIO_ACCESS_KEY=minioAccessKey"
-      - "MINIO_SECRET_KEY=minioVerySecretKey"
+      - "MINIO_ROOT_USER=minioAccessKey"
+      - "MINIO_ROOT_PASSWORD=minioVerySecretKey"
     command: server /data
     healthcheck:
       test: >

--- a/justfile
+++ b/justfile
@@ -41,7 +41,7 @@ build-cli:
 
 # Build release container using spec from docker-compose.yml
 containerize:
-	docker-compose build
+	docker compose build
 
 # Build sdk container without executing second stage
 containerize-dev:

--- a/justfile
+++ b/justfile
@@ -8,15 +8,15 @@ _create_from_sample PROJECT NAME EXTENSION:
 
 # Start the docker compose stack
 up *ARGS: (_create_from_sample "Eurofurence.App.Server.Web" "appsettings" "json") (_create_from_sample "Eurofurence.App.Server.Web" "firebase" "json") 
-	docker-compose up {{ARGS}}
+	docker compose up {{ARGS}}
 
 # Bring the docker compose stack down and remove volumes
 down:
-	docker-compose down -v --remove-orphans
+	docker compose down -v --remove-orphans
 
 # Stop the docker compose stack
 stop:
-	docker-compose stop
+	docker compose stop
 
 # Clean build, stack, container images and artifacts
 clean:
@@ -24,7 +24,7 @@ clean:
 	rm -rf artifacts build
 	find . -type d -name "bin" -print0 | xargs -0 rm -rf
 	find . -type d -name "obj" -print0 | xargs -0 rm -rf
-	docker-compose down || true
+	docker compose down || true
 	docker rmi ghcr.io/eurofurence/ef-app_backend-dotnet-core:dev-sdk || true
 	docker rmi ghcr.io/eurofurence/ef-app_backend-dotnet-core:nightly || true
 

--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ clean:
 	find . -type d -name "obj" -print0 | xargs -0 rm -rf
 	docker-compose down || true
 	docker rmi ghcr.io/eurofurence/ef-app_backend-dotnet-core:dev-sdk || true
-	docker rmi ghcr.io/eurofurence/ef-app_backend-dotnet-core:dev || true
+	docker rmi ghcr.io/eurofurence/ef-app_backend-dotnet-core:nightly || true
 
 # Perform restore, build & publish with dotnet
 build:

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ _create_from_sample PROJECT NAME EXTENSION:
 	if [ ! -f "{{NAME}}.{{EXTENSION}}" ]; then cp "src/{{PROJECT}}/{{NAME}}.sample.{{EXTENSION}}" "{{NAME}}.{{EXTENSION}}"; fi
 
 # Start the docker compose stack
-up *ARGS: (_create_from_sample "Eurofurence.App.Server.Web" "appsettings" "json") (_create_from_sample "Eurofurence.App.Server.Web" "firebase" "json")
+up *ARGS: (_create_from_sample "Eurofurence.App.Server.Web" "appsettings" "json") (_create_from_sample "Eurofurence.App.Server.Web" "firebase" "json") 
 	docker-compose up {{ARGS}}
 
 # Bring the docker compose stack down and remove volumes

--- a/src/Eurofurence.App.Server.Web/appsettings.sample.json
+++ b/src/Eurofurence.App.Server.Web/appsettings.sample.json
@@ -1,7 +1,4 @@
 ﻿{
-  "ConnectionStrings": {
-    "Eurofurence": "Server=127.0.0.1; Port=3306; Database=ef_backend; user=root; SslMode=Preferred;"
-  },
   "Identity": {
     "ClientId": "",
     "IntrospectionEndpoint": "https://identity.eurofurence.org/api/v1/introspect",
@@ -80,10 +77,10 @@
     "apiKey": ""
   },
   "minIo": {
-    "endpoint": "",
-    "accessKey": "",
-    "secretKey": "",
-    "secure": true, // Use SSL
-    "bucket": ""
+    "endpoint": "minio",
+    "accessKey": "minioAccessKey",
+    "secretKey": "minioVerySecretKey",
+    "secure": false,
+    "bucket": "ef-mobile-app-local"
   }
 }


### PR DESCRIPTION
Added a MinIO container to the `docker-compose.yml` for local testing. To verify, run `just clean; just containerize; just up` in the root of the repo and wait until `minio-init` has completed (might take a few seconds).
If `just` is unavailable, try running the following in the root of the repo:
```bash
docker compose down;
docker rmi ghcr.io/eurofurence/ef-app_backend-dotnet-core:nightly;
rm appsettings.json;
cp src/Eurofurence.App.Server.Web/appsettings.sample.json appsettings.json;
docker compose build;
docker compose up;
```
_Caution:_ This will replace your `appsettings.json` with the default for local development!