### PR TITLE
feat: Using font awesome icon name instead of unicode adress in knowledge base groups

### DIFF
--- a/src/Eurofurence.App.Domain.Model/Knowledge/KnowledgeGroupRecord.cs
+++ b/src/Eurofurence.App.Domain.Model/Knowledge/KnowledgeGroupRecord.cs
@@ -22,6 +22,6 @@ namespace Eurofurence.App.Domain.Model.Knowledge
         public bool ShowInHamburgerMenu { get; set; }
 
         [DataMember]
-        public string FontAwesomeIconCharacterUnicodeAddress { get; set; }
+        public string FontAwesomeIconName { get; set; }
     }
 }

--- a/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240629111313_ReplacedFontAwesomeUnicodeByName.Designer.cs
+++ b/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240629111313_ReplacedFontAwesomeUnicodeByName.Designer.cs
@@ -4,6 +4,7 @@ using Eurofurence.App.Infrastructure.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Eurofurence.App.Infrastructure.EntityFramework.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240629111313_ReplacedFontAwesomeUnicodeByName")]
+    partial class ReplacedFontAwesomeUnicodeByName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240629111313_ReplacedFontAwesomeUnicodeByName.cs
+++ b/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240629111313_ReplacedFontAwesomeUnicodeByName.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eurofurence.App.Infrastructure.EntityFramework.Migrations
+{
+    /// <inheritdoc />
+    public partial class ReplacedFontAwesomeUnicodeByName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "FontAwesomeIconCharacterUnicodeAddress",
+                table: "KnowledgeGroups",
+                newName: "FontAwesomeIconName");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "FontAwesomeIconName",
+                table: "KnowledgeGroups",
+                newName: "FontAwesomeIconCharacterUnicodeAddress");
+        }
+    }
+}

--- a/src/Eurofurence.App.Server.Web/Views/WebPreview/KnowledgeGroupsPreview.cshtml
+++ b/src/Eurofurence.App.Server.Web/Views/WebPreview/KnowledgeGroupsPreview.cshtml
@@ -27,7 +27,7 @@
 
     <section class="row desktopOnly">
         <div class="one columns">
-            <h4><i class="fa">&#x@(knowledgeGroup.FontAwesomeIconCharacterUnicodeAddress);</i></h4>
+            <h4><i class="fa fa-@(knowledgeGroup.FontAwesomeIconName)"></i></h4>
         </div>
         <div class="eleven columns">
             <h4>@knowledgeGroup.Name</h4>
@@ -37,22 +37,25 @@
 
 
     <section class="mobileOnly center nomargin">
-        <h2><i class="fa">&#x@(knowledgeGroup.FontAwesomeIconCharacterUnicodeAddress);</i></h2>
+        <h2><i class="fa fa-@(knowledgeGroup.FontAwesomeIconName)"></i></h2>
         <h4>@knowledgeGroup.Name</h4>
         <small>@knowledgeGroup.Description</small>
         <br /><br />
     </section>
 
 
-    @foreach (var knowledgeEntry in knowledgeEntries.Where(a => a.KnowledgeGroupId == knowledgeGroup.Id).OrderBy(a => a.Order)) {
-        <section class="row">
-            <div class="one columns desktopOnly">&nbsp;</div>
-            <div class="eleven columns">
-                <a class="button" href="@webBaseUrl/KnowledgeEntries/@knowledgeEntry.Id">
-                    @knowledgeEntry.Title
-                </a>
-            </div>
-        </section>
+    @if (knowledgeEntries != null)
+    {
+        foreach (var knowledgeEntry in knowledgeEntries.Where(a => a.KnowledgeGroupId == knowledgeGroup.Id).OrderBy(a => a.Order))
+        {
+            <section class="row">
+                <div class="one columns desktopOnly">&nbsp;</div>
+                <div class="eleven columns">
+                    <a class="button" href="@webBaseUrl/KnowledgeEntries/@knowledgeEntry.Id">
+                        @knowledgeEntry.Title
+                    </a>
+                </div>
+            </section>
+        }
     }
-
 }

--- a/src/Eurofurence.App.Tools.CliToolBox/Importers/Knowledge/WikIFileImporter.cs
+++ b/src/Eurofurence.App.Tools.CliToolBox/Importers/Knowledge/WikIFileImporter.cs
@@ -55,7 +55,7 @@ namespace Eurofurence.App.Tools.CliToolBox.Importers.Knowledge
                     Id = titleParts[0].AsHashToGuid(),
                     Name = titleParts[0],
                     Description = titleParts[1],
-                    FontAwesomeIconCharacterUnicodeAddress = titleParts[2],
+                    FontAwesomeIconName = titleParts[2],
                     Order = i++
                 };
                 importedKnowledgeGroups.Add(knowledgeGroup);
@@ -192,7 +192,7 @@ namespace Eurofurence.App.Tools.CliToolBox.Importers.Knowledge
                 .Map(s => s.Id, t => t.Id)
                 .Map(s => s.Name, t => t.Name)
                 .Map(s => s.Description, t => t.Description)
-                .Map(s => s.FontAwesomeIconCharacterUnicodeAddress, t => t.FontAwesomeIconCharacterUnicodeAddress)
+                .Map(s => s.FontAwesomeIconName, t => t.FontAwesomeIconName)
                 .Map(s => s.Order, t => t.Order);
 
             var diff = patch.Patch(importKnowledgeGroups, knowledgeGroupRecords);


### PR DESCRIPTION
BREAKING CHANGE: FontAwesomeIconCharacterUnicodeAddress renamed to FontAwesomeIconName. 
It will be filled by the backoffice with the icon name, e.g. "info", instead of the unicode address.