### PR TITLE
Configurable Authorization

### DIFF
--- a/src/Eurofurence.App.Server.Web/Controllers/KnowledgeEntriesController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/KnowledgeEntriesController.cs
@@ -28,6 +28,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         [HttpGet]
         [ProducesResponseType(typeof(string), 404)]
         [ProducesResponseType(typeof(IEnumerable<KnowledgeEntryRecord>), 200)]
+        [Authorize]
         public IQueryable<KnowledgeEntryRecord> GetKnowledgeEntriesAsync()
         {
             return _knowledgeEntryService.FindAll()

--- a/src/Eurofurence.App.Server.Web/Controllers/KnowledgeEntriesController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/KnowledgeEntriesController.cs
@@ -28,7 +28,6 @@ namespace Eurofurence.App.Server.Web.Controllers
         [HttpGet]
         [ProducesResponseType(typeof(string), 404)]
         [ProducesResponseType(typeof(IEnumerable<KnowledgeEntryRecord>), 200)]
-        [Authorize]
         public IQueryable<KnowledgeEntryRecord> GetKnowledgeEntriesAsync()
         {
             return _knowledgeEntryService.FindAll()

--- a/src/Eurofurence.App.Server.Web/Identity/AuthorizationOptions.cs
+++ b/src/Eurofurence.App.Server.Web/Identity/AuthorizationOptions.cs
@@ -4,11 +4,21 @@ namespace Eurofurence.App.Server.Web.Identity;
 
 public class AuthorizationOptions
 {
+    public HashSet<string> Attendee { get; set; } = new();
+    
     public HashSet<string> System { get; set; } = new();
+    
+    public HashSet<string> Admin { get; set; } = new();
 
     public HashSet<string> Developer { get; set; } = new();
 
     public HashSet<string> KnowledgeBaseMaintainer { get; set; } = new();
     
     public HashSet<string> ArtShow { get; set; } = new();
+    
+    public HashSet<string> FursuitBadgeSystem { get; set; } = new();
+    
+    public HashSet<string> PrivateMessagesSend { get; set; } = new();
+    
+    public HashSet<string> PrivateMessagesQuery { get; set; } = new();
 }

--- a/src/Eurofurence.App.Server.Web/Identity/AuthorizationOptions.cs
+++ b/src/Eurofurence.App.Server.Web/Identity/AuthorizationOptions.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Eurofurence.App.Server.Web.Identity;
+
+public class AuthorizationOptions
+{
+    public HashSet<string> System { get; set; } = new();
+
+    public HashSet<string> Developer { get; set; } = new();
+
+    public HashSet<string> KnowledgeBaseMaintainer { get; set; } = new();
+    
+    public HashSet<string> ArtShow { get; set; } = new();
+}

--- a/src/Eurofurence.App.Server.Web/Identity/RolesClaimsTransformation.cs
+++ b/src/Eurofurence.App.Server.Web/Identity/RolesClaimsTransformation.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace Eurofurence.App.Server.Web.Identity;
+
+public class RolesClaimsTransformation(IOptionsSnapshot<AuthorizationOptions> options) : IClaimsTransformation
+{
+    public Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
+    {
+        if (principal.Identity is not ClaimsIdentity identity)
+        {
+            return Task.FromResult(principal);
+        }
+
+        var roles = new HashSet<string>();
+
+        foreach (var claim in identity.Claims.Where(x => x.Type == "groups"))
+        {
+            if (options.Value.System.Contains(claim.Value))
+            {
+                roles.Add("System");
+            }
+
+            if (options.Value.Developer.Contains(claim.Value))
+            {
+                roles.Add("Developer");
+            }
+
+            if (options.Value.KnowledgeBaseMaintainer.Contains(claim.Value))
+            {
+                roles.Add("KnowledgeBase-Maintainer");
+            }
+
+            if (options.Value.ArtShow.Contains(claim.Value))
+            {
+                roles.Add("ArtShow");
+            }
+        }
+
+        foreach (var role in roles)
+        {
+            identity.AddClaim(new Claim(identity.RoleClaimType, role));
+        }
+
+
+        return Task.FromResult(principal);
+    }
+}

--- a/src/Eurofurence.App.Server.Web/Identity/RolesClaimsTransformation.cs
+++ b/src/Eurofurence.App.Server.Web/Identity/RolesClaimsTransformation.cs
@@ -20,6 +20,16 @@ public class RolesClaimsTransformation(IOptionsSnapshot<AuthorizationOptions> op
 
         foreach (var claim in identity.Claims.Where(x => x.Type == "groups"))
         {
+            if (options.Value.Attendee.Contains(claim.Value))
+            {
+                roles.Add("Attendee");
+            }
+            
+            if (options.Value.Admin.Contains(claim.Value))
+            {
+                roles.Add("Admin");
+            }
+            
             if (options.Value.System.Contains(claim.Value))
             {
                 roles.Add("System");
@@ -38,6 +48,21 @@ public class RolesClaimsTransformation(IOptionsSnapshot<AuthorizationOptions> op
             if (options.Value.ArtShow.Contains(claim.Value))
             {
                 roles.Add("ArtShow");
+            }
+            
+            if (options.Value.FursuitBadgeSystem.Contains(claim.Value))
+            {
+                roles.Add("FursuitBadgeSystem");
+            }
+            
+            if (options.Value.PrivateMessagesSend.Contains(claim.Value))
+            {
+                roles.Add("Action-PrivateMessages-Send");
+            }
+            
+            if (options.Value.PrivateMessagesQuery.Contains(claim.Value))
+            {
+                roles.Add("Action-PrivateMessages-Query");
             }
         }
 

--- a/src/Eurofurence.App.Server.Web/Startup.cs
+++ b/src/Eurofurence.App.Server.Web/Startup.cs
@@ -27,6 +27,7 @@ using Eurofurence.App.Server.Web.Identity;
 using IdentityModel.AspNetCore.OAuth2Introspection;
 using Microsoft.OpenApi.Models;
 using Eurofurence.App.Server.Services.Abstractions.MinIO;
+using Microsoft.AspNetCore.Authentication;
 using Minio;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
@@ -151,13 +152,14 @@ namespace Eurofurence.App.Server.Web
             });
 
             services.Configure<IdentityOptions>(Configuration.GetSection("Identity"));
+            services.Configure<AuthorizationOptions>(Configuration.GetSection("Authorization"));
             services.ConfigureOptions<ConfigureOAuth2IntrospectionOptions>();
 
+            services.AddTransient<IClaimsTransformation, RolesClaimsTransformation>();
             services.AddAuthentication(OAuth2IntrospectionDefaults.AuthenticationScheme)
                 .AddOAuth2Introspection(options =>
                 {
                     options.EnableCaching = true;
-                    options.RoleClaimType = "groups";
                 });
 
             services.AddControllersWithViews()

--- a/src/Eurofurence.App.Server.Web/appsettings.sample.json
+++ b/src/Eurofurence.App.Server.Web/appsettings.sample.json
@@ -4,6 +4,17 @@
     "IntrospectionEndpoint": "https://identity.eurofurence.org/api/v1/introspect",
     "UserInfoEndpoint": "https://identity.eurofurence.org/api/v1/userinfo"
   },
+  "Authorization": {
+    "Attendee": [],
+    "System": [],
+    "Admin": [],
+    "Developer": [],
+    "KnowledgeBaseMaintainer": [],
+    "ArtShow": [],
+    "FursuitBadgeSystem": [],
+    "PrivateMessagesSend": [],
+    "PrivateMessagesQuery": []
+  },
   "global": {
     "conventionNumber": 99,
     "conventionIdentifier": "EFXX",
@@ -30,7 +41,7 @@
   "firebase": {
     "googleServiceCredentialKeyFile": "firebase.json",
     "topics": [
-       "EFXX"
+      "EFXX"
     ],
     "expo": {
       "scopeKey": "@eurofurence/ef-app-react-native",


### PR DESCRIPTION
This PR adds a configurable mapping from IDP groups to backend roles.
Each role in the backend has a list of corresponding IDP groups under the `Authorization` section in the `appsettings.json`.
The groups are mapped, unified and assigned to the claims principal using a claims transformer.