### PR TITLE
feat(dealers): expand model by keywords

### DIFF
--- a/src/Eurofurence.App.Domain.Model/Dealers/DealerRecord.cs
+++ b/src/Eurofurence.App.Domain.Model/Dealers/DealerRecord.cs
@@ -136,6 +136,12 @@ namespace Eurofurence.App.Domain.Model.Dealers
         [DataMember]
         public string[] Categories { get; set; }
 
+        /// <summary>
+        /// **(pba)** JSON string of keywords grouped by categories, that apply to the goods/services sold/offered by the dealer.
+        /// </summary>
+        [DataMember]
+        public Dictionary<string, string[]> Keywords { get; set; }
+
         public string DisplayNameOrAttendeeNickname =>
             !string.IsNullOrWhiteSpace(DisplayName) ? DisplayName : AttendeeNickname;
 

--- a/src/Eurofurence.App.Infrastructure.EntityFramework/AppDbContext.cs
+++ b/src/Eurofurence.App.Infrastructure.EntityFramework/AppDbContext.cs
@@ -70,6 +70,9 @@ namespace Eurofurence.App.Infrastructure.EntityFramework
 
             modelBuilder.Entity<RegSysAlternativePinRecord>().Property(x => x.PinConsumptionDatesUtc)
                 .HasColumnType("json");
+
+            modelBuilder.Entity<DealerRecord>().Property(x => x.Keywords)
+                .HasColumnType("json");
         }
     }
 }

--- a/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240718162505_AddedKeywordsToDealers.Designer.cs
+++ b/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240718162505_AddedKeywordsToDealers.Designer.cs
@@ -4,6 +4,7 @@ using Eurofurence.App.Infrastructure.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Eurofurence.App.Infrastructure.EntityFramework.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240718162505_AddedKeywordsToDealers")]
+    partial class AddedKeywordsToDealers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240718162505_AddedKeywordsToDealers.cs
+++ b/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240718162505_AddedKeywordsToDealers.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eurofurence.App.Infrastructure.EntityFramework.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddedKeywordsToDealers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Keywords",
+                table: "Dealers",
+                type: "json",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Keywords",
+                table: "Dealers");
+        }
+    }
+}

--- a/src/Eurofurence.App.Server.Services/Dealers/DealerService.cs
+++ b/src/Eurofurence.App.Server.Services/Dealers/DealerService.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
 using Eurofurence.App.Domain.Model.Dealers;
 using Eurofurence.App.Infrastructure.EntityFramework;
 using Eurofurence.App.Server.Services.Abstractions;
@@ -19,6 +21,21 @@ namespace Eurofurence.App.Server.Services.Dealers
             : base(appDbContext, storageServiceFactory)
         {
             _appDbContext = appDbContext;
+        }
+
+        public override async Task<DealerRecord> FindOneAsync(Guid id)
+        {
+            return await _appDbContext.Dealers
+                .Include(d => d.Links)
+                .AsNoTracking()
+                .FirstOrDefaultAsync(entity => entity.Id == id);
+        }
+
+        public override IQueryable<DealerRecord> FindAll()
+        {
+            return _appDbContext.Dealers
+                .Include(d => d.Links)
+                .AsNoTracking();
         }
 
         public override async Task ReplaceOneAsync(DealerRecord entity)

--- a/src/Eurofurence.App.Tools.CliToolBox/Importers/DealersDen/PackageImporter.cs
+++ b/src/Eurofurence.App.Tools.CliToolBox/Importers/DealersDen/PackageImporter.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using CsvHelper;
 using CsvHelper.Configuration;
@@ -65,7 +66,8 @@ namespace Eurofurence.App.Tools.CliToolBox.Importers.DealersDen
                         TelegramHandle = record.Telegram.Trim(),
                         TwitterHandle = record.Twitter.Trim(),
                         IsAfterDark = !string.IsNullOrWhiteSpace(record.AfterDark),
-                        Categories = record.GetCategories().ToArray()
+                        Keywords = record.GetKeywords(),
+                        Categories = record.GetCategories()
                     };
 
                     dealerRecord.ArtistImageId = await GetImageIdAsync(archive, $"artist_{record.RegNo}.",
@@ -106,7 +108,8 @@ namespace Eurofurence.App.Tools.CliToolBox.Importers.DealersDen
                 .Map(s => s.AttendsOnSaturday, t => t.AttendsOnSaturday)
                 .Map(s => s.Categories, t => t.Categories)
                 .Map(s => s.IsAfterDark, t => t.IsAfterDark)
-                .Map(s => s.Links, t => t.Links);
+                .Map(s => s.Links, t => t.Links)
+                .Map(s => s.Keywords, t => t.Keywords);
 
             var diff = patch.Patch(importRecords, existingRecords);
             await _dealerService.ApplyPatchOperationAsync(diff);
@@ -209,11 +212,7 @@ namespace Eurofurence.App.Tools.CliToolBox.Importers.DealersDen
             Map(m => m.AttendsFri).Name("Attends Fri");
             Map(m => m.AttendsSat).Name("Attends Sat");
             Map(m => m.AfterDark).Name("After Dark");
-            Map(m => m.CategoryPrints).Name("Cat. Prints");
-            Map(m => m.CategoryArtwork).Name("Cat. Artwork");
-            Map(m => m.CategoryFursuits).Name("Cat. Fursuit");
-            Map(m => m.CategoryCommissions).Name("Cat. Commissions");
-            Map(m => m.CategoryMiscellaneous).Name("Cat. Misc");
+            Map(m => m.Keywords).Name("Keywords");
         }
     }
 
@@ -234,23 +233,28 @@ namespace Eurofurence.App.Tools.CliToolBox.Importers.DealersDen
         public string Telegram { get; set; }
         public string Twitter { get; set; }
         public string AfterDark { get; set; }
-        public string CategoryPrints { get; set; }
-        public string CategoryArtwork { get; set; }
-        public string CategoryFursuits { get; set; }
-        public string CategoryCommissions { get; set; }
-        public string CategoryMiscellaneous { get; set; }
+        public string Keywords { get; set; }
 
-        public IList<string> GetCategories()
+        public string[] GetCategories()
         {
-            var categories = new List<string>();
+            if (string.IsNullOrEmpty(Keywords))
+        {
+                return [];
+            }
 
-            if (!string.IsNullOrWhiteSpace(CategoryPrints)) categories.Add("Prints");
-            if (!string.IsNullOrWhiteSpace(CategoryArtwork)) categories.Add("Artwork");
-            if (!string.IsNullOrWhiteSpace(CategoryFursuits)) categories.Add("Fursuits");
-            if (!string.IsNullOrWhiteSpace(CategoryCommissions)) categories.Add("Commissions");
-            if (!string.IsNullOrWhiteSpace(CategoryMiscellaneous) || categories.Count == 0) categories.Add("Miscellaneous");
+            var keywords = GetKeywords();
 
-            return categories;
+            return [..keywords.Keys];
+        }
+
+        public Dictionary<string, string[]> GetKeywords()
+        {
+            if (string.IsNullOrEmpty(Keywords))
+            {
+                return new Dictionary<string, string[]>();
+            }
+
+            return JsonSerializer.Deserialize<Dictionary<string, string[]>>(Keywords);
         }
     }
 }

--- a/src/Eurofurence.App.Tools.CliToolBox/Importers/DealersDen/PackageImporter.cs
+++ b/src/Eurofurence.App.Tools.CliToolBox/Importers/DealersDen/PackageImporter.cs
@@ -178,7 +178,7 @@ namespace Eurofurence.App.Tools.CliToolBox.Importers.DealersDen
             dealerRecord.Links = linkFragments;
         }
 
-        private async Task<Guid?> GetImageIdAsync(ZipArchive archive, string fileNameStartsWith,
+        private async Task<Guid?>GetImageIdAsync(ZipArchive archive, string fileNameStartsWith,
             string internalReference)
         {
             var imageEntry =
@@ -187,8 +187,10 @@ namespace Eurofurence.App.Tools.CliToolBox.Importers.DealersDen
 
             if (imageEntry == null) return null;
 
-            await using var s = imageEntry.Open();
-            var result = await _imageService.InsertImageAsync(internalReference, s);
+            var stream = imageEntry.Open();
+            using var ms = new MemoryStream();
+            await stream.CopyToAsync(ms);
+            var result = await _imageService.InsertImageAsync(internalReference, ms);
             return result?.Id;
         }
     }
@@ -238,7 +240,7 @@ namespace Eurofurence.App.Tools.CliToolBox.Importers.DealersDen
         public string[] GetCategories()
         {
             if (string.IsNullOrEmpty(Keywords))
-        {
+            {
                 return [];
             }
 


### PR DESCRIPTION
This pull request adds the keywords property to the dealers model.
The categories are now imported from the keys of the keywords.

Also, a few minor issues were fixed in the dealers import and dealer queries.

Example result with the new keywords:

```
"Categories": [
      "Commissions and Services",
      "Music and Audio",
      "Plushies"
    ],
    "Keywords": {
      "Commissions and Services": [
        "VR Integration",
        "Workshops, Classes, Tutorials"
      ],
      "Music and Audio": [
        "Music and Audio (Other)"
      ],
      "Plushies": [
        "Plushy Animals"
      ]
    },
```