### PR TITLE
feat: add response and request models to hide relations from api

### DIFF
--- a/src/Eurofurence.App.Backoffice/Components/ImageDialog.razor
+++ b/src/Eurofurence.App.Backoffice/Components/ImageDialog.razor
@@ -1,93 +1,46 @@
 ﻿@using Eurofurence.App.Backoffice.Services
-@using Eurofurence.App.Domain.Model.ArtistsAlley
-@using Eurofurence.App.Domain.Model.Dealers
-@using Eurofurence.App.Domain.Model.Fursuits
 @using Eurofurence.App.Domain.Model.Images
-@using Eurofurence.App.Domain.Model.Knowledge
 @inject ISnackbar Snackbar
 @inject IImageService ImageService
-@inject IKnowledgeService KnowledgeService
-@inject IArtistAlleyService ArtistAlleyService
-@inject IFursuitService FursuitService
-@inject IDealerService DealerService
 
 <MudDialog>
     <DialogContent>
         @if (Record != null)
         {
             <MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-6">
-                <MudContainer Style="height: 60vh" Class="overflow-scroll pr-4">
-                    <MudTabPanel Icon="@Icons.Material.Outlined.Image" Text="General">
-                        <MudGrid>
-                            <MudItem xs="6">
-                                <MudImage ObjectFit="ObjectFit.Contain" Height="400" Width="500" Class="ml-2" Src="@_imageSource">
-                                    @if (string.IsNullOrEmpty(_imageSource))
-                                    {
-                                        <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
-                                    }
-                                </MudImage>
+                <MudContainer Style="height: 600px" Class="overflow-scroll pr-4">
+                    <MudGrid>
+                        <MudItem xs="6">
+                            <MudImage ObjectFit="ObjectFit.Contain" Height="500" Width="500" Class="ml-2" Src="@_imageSource">
+                                @if (string.IsNullOrEmpty(_imageSource))
+                                {
+                                    <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
+                                }
+                            </MudImage>
+                        </MudItem>
+                        <MudItem xs="6">
+                            <MudFileUpload T="IBrowserFile" FilesChanged="UploadImage">
+                                <ActivatorContent>
+                                    <MudButton Variant="Variant.Filled"
+                                               Color="Color.Primary"
+                                               StartIcon="@Icons.Material.Filled.CloudUpload"
+                                               Class="mb-2">
+                                        Upload Image
+                                    </MudButton>
+                                </ActivatorContent>
+                            </MudFileUpload>
+                            <MudTextField Value="Record.Id" Label="ID" ReadOnly="true"/>
+                            <MudTextField T="string" Value="Record.InternalReference" Label="Name" ReadOnly="true"/>
+                            <MudTextField Value="Record.SizeInBytes" Label="Size (Bytes)" ReadOnly="true"/>
+                            <MudTextField Value="Record.MimeType" Label="Mime type" ReadOnly="true"/>
+                            <MudItem xs="3">
+                                <MudTextField Value="Record.Width" Label="Width" ReadOnly="true"/>
                             </MudItem>
-                            <MudItem xs="6">
-                                <MudFileUpload T="IBrowserFile" FilesChanged="UploadImage">
-                                    <ActivatorContent>
-                                        <MudButton Variant="Variant.Filled"
-                                                   Color="Color.Primary"
-                                                   StartIcon="@Icons.Material.Filled.CloudUpload"
-                                                   Class="mb-2">
-                                            Upload Image
-                                        </MudButton>
-                                    </ActivatorContent>
-                                </MudFileUpload>
-                                <MudTextField Value="Record.Id" Label="ID" ReadOnly="true"/>
-                                <MudTextField T="string" Value="Record.InternalReference" Label="Name" ReadOnly="true"/>
-                                <MudTextField Value="Record.SizeInBytes" Label="Size (Bytes)" ReadOnly="true"/>
-                                <MudTextField Value="Record.MimeType" Label="Mime type" ReadOnly="true"/>
-                                <MudItem xs="3">
-                                    <MudTextField Value="Record.Width" Label="Width" ReadOnly="true"/>
-                                </MudItem>
-                                <MudItem xs="3">
-                                    <MudTextField Value="Record.Height" Label="Height" ReadOnly="true"/>
-                                </MudItem>
+                            <MudItem xs="3">
+                                <MudTextField Value="Record.Height" Label="Height" ReadOnly="true"/>
                             </MudItem>
-                        </MudGrid>
-                    </MudTabPanel>
-                    <MudTabPanel Icon="@Icons.Material.Outlined.Badge" Text="Fursuit Badges">
-                        <MudDataGrid Items="@_fursuitBadges" Filterable="false" SortMode="@SortMode.None" Groupable="false">
-                            <Columns>
-                                <PropertyColumn Title="ID" Property="fursuitBadge => fursuitBadge.Id"/>
-                                <PropertyColumn Title="Name" Property="fursuitBadge => fursuitBadge.Name"/>
-                                <PropertyColumn Title="Worn By" Property="fursuitBadge => fursuitBadge.WornBy"/>
-                            </Columns>
-                        </MudDataGrid>
-                    </MudTabPanel>
-                    <MudTabPanel Icon="@Icons.Material.Outlined.TableRestaurant" Text="Artist Alley Table Registrations">
-                        <MudDataGrid Items="@_tableRegistrations" Filterable="false" SortMode="@SortMode.None" Groupable="false">
-                            <Columns>
-                                <PropertyColumn Title="ID" Property="tableRegistration => tableRegistration.Id" />
-                                <PropertyColumn Title="Name" Property="tableRegistration => tableRegistration.DisplayName" />
-                                <PropertyColumn Title="Location" Property="tableRegistration => tableRegistration.Location" />
-                                <PropertyColumn Title="Description" Property="tableRegistration => tableRegistration.ShortDescription" />
-                            </Columns>
-                        </MudDataGrid>
-                    </MudTabPanel>
-                    <MudTabPanel Icon="@Icons.Material.Outlined.Info" Text="Knowledge Base Entries">
-                        <MudDataGrid Items="@_knowledgeEntries" Filterable="false" SortMode="@SortMode.None" Groupable="false">
-                            <Columns>
-                                <PropertyColumn Title="ID" Property="knowledgeEntry => knowledgeEntry.Id" />
-                                <PropertyColumn Title="Title" Property="knowledgeEntry => knowledgeEntry.Title" />
-                                <PropertyColumn Title="Group ID" Property="knowledgeEntry => knowledgeEntry.KnowledgeGroupId" />
-                            </Columns>
-                        </MudDataGrid>
-                    </MudTabPanel>
-                    <MudTabPanel Icon="@Icons.Material.Outlined.Shop" Text="Dealers">
-                        <MudDataGrid Items="@_dealers" Filterable="false" SortMode="@SortMode.None" Groupable="false">
-                            <Columns>
-                                <PropertyColumn Title="ID" Property="dealer => dealer.Id" />
-                                <PropertyColumn Title="Name" Property="dealer => dealer.DisplayNameOrAttendeeNickname" />
-                                <PropertyColumn Title="Description" Property="dealer => dealer.ShortDescription" />
-                            </Columns>
-                        </MudDataGrid>
-                    </MudTabPanel>
+                        </MudItem>
+                    </MudGrid>
                 </MudContainer>
             </MudTabs>
         }
@@ -100,14 +53,9 @@
 @code {
     [CascadingParameter] private MudDialogInstance MudDialog { get; set; }
 
-    [Parameter] public ImageRecord? Record { get; set; }
+    [Parameter] public ImageWithRelationsResponse? Record { get; set; }
 
     private bool Update { get; set; }
-
-    private IEnumerable<KnowledgeEntryResponse> _knowledgeEntries = new List<KnowledgeEntryResponse>();
-    private IEnumerable<TableRegistrationResponse> _tableRegistrations = new List<TableRegistrationResponse>();
-    private IEnumerable<FursuitBadgeResponse> _fursuitBadges = new List<FursuitBadgeResponse>();
-    private IEnumerable<DealerRecord> _dealers = new List<DealerRecord>();
 
     private string _imageSource = string.Empty;
 
@@ -115,29 +63,13 @@
     {
         if (Record == null)
         {
-            Record = new ImageRecord
-            {
-                Id = Guid.NewGuid()
-            };
+            Record = new ImageWithRelationsResponse();
         }
         else
         {
             Update = true;
-            await LoadRelatedEntities();
             await LoadImageSourceAsync();
         }
-    }
-
-    private async Task LoadRelatedEntities()
-    {
-        if (Record == null)
-        {
-            return;
-        }
-        _knowledgeEntries = (await KnowledgeService.GetKnowledgeEntriesAsync()).Where(knowledgeEntry => knowledgeEntry.Images.Any(image => image.Id == Record.Id)).OrderBy(ke => ke.Order);
-        _tableRegistrations = (await ArtistAlleyService.GetTableRegistrationsAsync()).Where(tableRegistration => tableRegistration.Image?.Id == Record.Id);
-        _fursuitBadges = (await FursuitService.GetFursuitBadgesAsync()).Where(fursuitBadge => fursuitBadge.Image?.Id == Record.Id);
-        _dealers = (await DealerService.GetDealersAsync()).Where(dealer => dealer.ArtPreviewImageId == Record.Id || dealer.ArtistImageId == Record.Id || dealer.ArtistThumbnailImageId == Record.Id);
     }
 
     private async Task LoadImageSourceAsync()

--- a/src/Eurofurence.App.Backoffice/Components/ImageDialog.razor
+++ b/src/Eurofurence.App.Backoffice/Components/ImageDialog.razor
@@ -1,9 +1,13 @@
 ﻿@using Eurofurence.App.Backoffice.Services
+@using Eurofurence.App.Domain.Model.ArtistsAlley
+@using Eurofurence.App.Domain.Model.Fursuits
 @using Eurofurence.App.Domain.Model.Images
 @using Eurofurence.App.Domain.Model.Knowledge
 @inject ISnackbar Snackbar
 @inject IImageService ImageService
 @inject IKnowledgeService KnowledgeService
+@inject IArtistAlleyService ArtistAlleyService
+@inject IFursuitService FursuitService
 
 <MudDialog>
     <DialogContent>
@@ -46,7 +50,7 @@
                         </MudGrid>
                     </MudTabPanel>
                     <MudTabPanel Icon="@Icons.Material.Outlined.Badge" Text="Fursuit Badges">
-                        <MudDataGrid Items="@Record.FursuitBadges" Filterable="false" SortMode="@SortMode.None" Groupable="false">
+                        <MudDataGrid Items="@_FursuitBadges" Filterable="false" SortMode="@SortMode.None" Groupable="false">
                             <Columns>
                                 <PropertyColumn Title="ID" Property="fursuitBadge => fursuitBadge.Id"/>
                                 <PropertyColumn Title="Name" Property="fursuitBadge => fursuitBadge.Name"/>
@@ -55,7 +59,7 @@
                         </MudDataGrid>
                     </MudTabPanel>
                     <MudTabPanel Icon="@Icons.Material.Outlined.TableRestaurant" Text="Artist Alley Table Registrations">
-                        <MudDataGrid Items="@Record.TableRegistrations" Filterable="false" SortMode="@SortMode.None" Groupable="false">
+                        <MudDataGrid Items="@_tableRegistrations" Filterable="false" SortMode="@SortMode.None" Groupable="false">
                             <Columns>
                                 <PropertyColumn Title="ID" Property="tableRegistration => tableRegistration.Id" />
                                 <PropertyColumn Title="Name" Property="tableRegistration => tableRegistration.DisplayName" />
@@ -89,7 +93,10 @@
 
     private bool Update { get; set; }
 
-    private IEnumerable<KnowledgeEntryRecord> _knowledgeEntries = new List<KnowledgeEntryRecord>();
+    private IEnumerable<KnowledgeEntryResponse> _knowledgeEntries = new List<KnowledgeEntryResponse>();
+    private IEnumerable<TableRegistrationResponse> _tableRegistrations = new List<TableRegistrationResponse>();
+    private IEnumerable<FursuitBadgeResponse> _FursuitBadges = new List<FursuitBadgeResponse>();
+
     private string _imageSource = string.Empty;
 
     protected override async Task OnInitializedAsync()
@@ -116,6 +123,8 @@
             return;
         }
         _knowledgeEntries = (await KnowledgeService.GetKnowledgeEntriesAsync()).Where(knowledgeEntry => knowledgeEntry.Images.Any(image => image.Id == Record.Id)).OrderBy(ke => ke.Order);
+        _tableRegistrations = (await ArtistAlleyService.GetTableRegistrationsAsync()).Where(tableRegistration => tableRegistration.Image.Id == Record.Id);
+        _FursuitBadges = (await FursuitService.GetFursuitBadgesAsync()).Where(fursuitBadge => fursuitBadge.Image.Id == Record.Id);
     }
 
     private async Task LoadImageSourceAsync()

--- a/src/Eurofurence.App.Backoffice/Components/ImageDialog.razor
+++ b/src/Eurofurence.App.Backoffice/Components/ImageDialog.razor
@@ -1,5 +1,6 @@
 ﻿@using Eurofurence.App.Backoffice.Services
 @using Eurofurence.App.Domain.Model.ArtistsAlley
+@using Eurofurence.App.Domain.Model.Dealers
 @using Eurofurence.App.Domain.Model.Fursuits
 @using Eurofurence.App.Domain.Model.Images
 @using Eurofurence.App.Domain.Model.Knowledge
@@ -8,6 +9,7 @@
 @inject IKnowledgeService KnowledgeService
 @inject IArtistAlleyService ArtistAlleyService
 @inject IFursuitService FursuitService
+@inject IDealerService DealerService
 
 <MudDialog>
     <DialogContent>
@@ -50,7 +52,7 @@
                         </MudGrid>
                     </MudTabPanel>
                     <MudTabPanel Icon="@Icons.Material.Outlined.Badge" Text="Fursuit Badges">
-                        <MudDataGrid Items="@_FursuitBadges" Filterable="false" SortMode="@SortMode.None" Groupable="false">
+                        <MudDataGrid Items="@_fursuitBadges" Filterable="false" SortMode="@SortMode.None" Groupable="false">
                             <Columns>
                                 <PropertyColumn Title="ID" Property="fursuitBadge => fursuitBadge.Id"/>
                                 <PropertyColumn Title="Name" Property="fursuitBadge => fursuitBadge.Name"/>
@@ -77,6 +79,15 @@
                             </Columns>
                         </MudDataGrid>
                     </MudTabPanel>
+                    <MudTabPanel Icon="@Icons.Material.Outlined.Shop" Text="Dealers">
+                        <MudDataGrid Items="@_dealers" Filterable="false" SortMode="@SortMode.None" Groupable="false">
+                            <Columns>
+                                <PropertyColumn Title="ID" Property="dealer => dealer.Id" />
+                                <PropertyColumn Title="Name" Property="dealer => dealer.DisplayNameOrAttendeeNickname" />
+                                <PropertyColumn Title="Description" Property="dealer => dealer.ShortDescription" />
+                            </Columns>
+                        </MudDataGrid>
+                    </MudTabPanel>
                 </MudContainer>
             </MudTabs>
         }
@@ -95,7 +106,8 @@
 
     private IEnumerable<KnowledgeEntryResponse> _knowledgeEntries = new List<KnowledgeEntryResponse>();
     private IEnumerable<TableRegistrationResponse> _tableRegistrations = new List<TableRegistrationResponse>();
-    private IEnumerable<FursuitBadgeResponse> _FursuitBadges = new List<FursuitBadgeResponse>();
+    private IEnumerable<FursuitBadgeResponse> _fursuitBadges = new List<FursuitBadgeResponse>();
+    private IEnumerable<DealerRecord> _dealers = new List<DealerRecord>();
 
     private string _imageSource = string.Empty;
 
@@ -111,12 +123,12 @@
         else
         {
             Update = true;
-            await LoadKnowledgeEntries();
+            await LoadRelatedEntities();
             await LoadImageSourceAsync();
         }
     }
 
-    private async Task LoadKnowledgeEntries()
+    private async Task LoadRelatedEntities()
     {
         if (Record == null)
         {
@@ -124,7 +136,8 @@
         }
         _knowledgeEntries = (await KnowledgeService.GetKnowledgeEntriesAsync()).Where(knowledgeEntry => knowledgeEntry.Images.Any(image => image.Id == Record.Id)).OrderBy(ke => ke.Order);
         _tableRegistrations = (await ArtistAlleyService.GetTableRegistrationsAsync()).Where(tableRegistration => tableRegistration.Image.Id == Record.Id);
-        _FursuitBadges = (await FursuitService.GetFursuitBadgesAsync()).Where(fursuitBadge => fursuitBadge.Image.Id == Record.Id);
+        _fursuitBadges = (await FursuitService.GetFursuitBadgesAsync()).Where(fursuitBadge => fursuitBadge.Image.Id == Record.Id);
+        _dealers = (await DealerService.GetDealersAsync()).Where(dealer => dealer.ArtPreviewImageId == Record.Id || dealer.ArtistImageId == Record.Id || dealer.ArtistThumbnailImageId == Record.Id);
     }
 
     private async Task LoadImageSourceAsync()

--- a/src/Eurofurence.App.Backoffice/Components/ImageDialog.razor
+++ b/src/Eurofurence.App.Backoffice/Components/ImageDialog.razor
@@ -135,8 +135,8 @@
             return;
         }
         _knowledgeEntries = (await KnowledgeService.GetKnowledgeEntriesAsync()).Where(knowledgeEntry => knowledgeEntry.Images.Any(image => image.Id == Record.Id)).OrderBy(ke => ke.Order);
-        _tableRegistrations = (await ArtistAlleyService.GetTableRegistrationsAsync()).Where(tableRegistration => tableRegistration.Image.Id == Record.Id);
-        _fursuitBadges = (await FursuitService.GetFursuitBadgesAsync()).Where(fursuitBadge => fursuitBadge.Image.Id == Record.Id);
+        _tableRegistrations = (await ArtistAlleyService.GetTableRegistrationsAsync()).Where(tableRegistration => tableRegistration.Image?.Id == Record.Id);
+        _fursuitBadges = (await FursuitService.GetFursuitBadgesAsync()).Where(fursuitBadge => fursuitBadge.Image?.Id == Record.Id);
         _dealers = (await DealerService.GetDealersAsync()).Where(dealer => dealer.ArtPreviewImageId == Record.Id || dealer.ArtistImageId == Record.Id || dealer.ArtistThumbnailImageId == Record.Id);
     }
 

--- a/src/Eurofurence.App.Backoffice/Components/KnowledgeEntryDialog.razor
+++ b/src/Eurofurence.App.Backoffice/Components/KnowledgeEntryDialog.razor
@@ -169,18 +169,9 @@
         }
     }
 
-    private async Task DeleteImage(Guid id)
+    private void DeleteImage(Guid id)
     {
-        var result = await ImageService.DeleteImageAsync(id);
-        if (result)
-        {
-            Record?.Images.Remove(Record.Images.FirstOrDefault(image => image.Id == id));
-            Snackbar.Add("Image deleted.", Severity.Success);
-        }
-        else
-        {
-            Snackbar.Add("Error deleting image.", Severity.Error);
-        }
+        Record?.Images.Remove(Record.Images.FirstOrDefault(image => image.Id == id));
     }
 
     private async Task AddLink()

--- a/src/Eurofurence.App.Backoffice/Components/KnowledgeEntryDialog.razor
+++ b/src/Eurofurence.App.Backoffice/Components/KnowledgeEntryDialog.razor
@@ -1,6 +1,7 @@
 ﻿@using Eurofurence.App.Domain.Model.Knowledge
 @using Eurofurence.App.Backoffice.Services
 @using Eurofurence.App.Domain.Model.Fragments
+@using Eurofurence.App.Domain.Model.Images
 @inject ISnackbar Snackbar
 @inject IKnowledgeService KnowledgeService
 @inject IImageService ImageService
@@ -148,7 +149,18 @@
         var image = await ImageService.PostImageAsync(file);
         if (image != null)
         {
-            Record?.Images.Add(image);
+            Record?.Images.Add(new ImageRecord()
+            {
+                Id = image.Id,
+                InternalReference = image.InternalReference,
+                MimeType = image.MimeType,
+                SizeInBytes = image.SizeInBytes,
+                LastChangeDateTimeUtc = image.LastChangeDateTimeUtc,
+                ContentHashSha1 = image.ContentHashSha1,
+                Height = image.Height,
+                Width = image.Width,
+                IsDeleted = image.IsDeleted
+            });
             Snackbar.Add("Image uploaded.", Severity.Success);
         }
         else

--- a/src/Eurofurence.App.Backoffice/Pages/Images.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/Images.razor
@@ -15,17 +15,17 @@
     <MudTextField T="string" ValueChanged="Search" Label="Search" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Secondary"/>
     <MudButton Class="ml-4" Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add" @onclick="AddImage">New image</MudButton>
 </MudToolBar>
-<MudDataGrid T="ImageRecord" @ref="_dataGrid" LoadingProgressColor="Color.Primary" ServerData="@GetImages" SortMode="@SortMode.None" Groupable="false">
+<MudDataGrid T="ImageWithRelationsResponse" @ref="_dataGrid" LoadingProgressColor="Color.Primary" ServerData="@GetImages" SortMode="@SortMode.None" Groupable="false">
     <Columns>
         <TemplateColumn Title="Preview" CellClass="d-flex justify-center">
             <CellTemplate>
                 @if (!string.IsNullOrEmpty(@_imageContents.FirstOrDefault(kvp => kvp.Key == @context.Item.Id).Value))
                 {
-                    <MudImage Class="ml-2" Width="100" Src="@_imageContents.FirstOrDefault(kvp => kvp.Key == @context.Item.Id).Value" />
+                    <MudImage Class="ml-2" Width="100" Src="@_imageContents.FirstOrDefault(kvp => kvp.Key == @context.Item.Id).Value"/>
                 }
                 else
                 {
-                    <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+                    <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
                 }
             </CellTemplate>
         </TemplateColumn>
@@ -33,8 +33,46 @@
         <PropertyColumn Title="Name" Property="image => image.InternalReference"/>
         <PropertyColumn Title="Size (Bytes)" Property="image => image.SizeInBytes"/>
         <PropertyColumn Title="Last Changed" Property="image => image.LastChangeDateTimeUtc"/>
-        <PropertyColumn Title="Fursuit Badges" Property="image => image.FursuitBadges.Count" />
-        <PropertyColumn Title="Artist Alley Table Registrations" Property="image => image.TableRegistrations.Count" />
+        <TemplateColumn Title="Usage">
+            <CellTemplate>
+                @if (context.Item?.FursuitBadgeIds.Count > 0)
+                {
+                    <MudTooltip Text="Fursuit Badges">
+                        <MudIcon Icon="@Icons.Material.Outlined.Badge"></MudIcon>
+                    </MudTooltip>
+                }
+                @if (context.Item?.TableRegistrationIds.Count > 0)
+                {
+                    <MudTooltip Text="Table Registrations">
+                        <MudIcon Icon="@Icons.Material.Outlined.TableRestaurant"></MudIcon>
+                    </MudTooltip>
+                }
+                @if (context.Item?.KnowledgeEntryIds.Count > 0)
+                {
+                    <MudTooltip Text="Knowledge Base">
+                        <MudIcon Icon="@Icons.Material.Outlined.Info"></MudIcon>
+                    </MudTooltip>
+                }
+                @if (context.Item?.MapIds.Count > 0)
+                {
+                    <MudTooltip Text="Maps">
+                        <MudIcon Icon="@Icons.Material.Outlined.Map"></MudIcon>
+                    </MudTooltip>
+                }
+                @if (context.Item?.DealerArtPreviewIds.Count > 0 || context.Item?.DealerArtistIds.Count > 0 || context.Item?.DealerArtistThumbnailIds.Count > 0)
+                {
+                    <MudTooltip Text="Dealers Den">
+                        <MudIcon Icon="@Icons.Material.Outlined.ShoppingCart"></MudIcon>
+                    </MudTooltip>
+                }
+                @if (context.Item?.EventBannerIds.Count > 0 || context.Item?.EventPosterIds.Count > 0)
+                {
+                    <MudTooltip Text="Events">
+                        <MudIcon Icon="@Icons.Material.Outlined.Event"></MudIcon>
+                    </MudTooltip>
+                }
+            </CellTemplate>
+        </TemplateColumn>
         <TemplateColumn>
             <CellTemplate>
                 @if (context.Item != null)
@@ -53,17 +91,18 @@
 
 @code {
     private string? _imageSearch;
-    private List<ImageRecord> _images = new();
+    private List<ImageWithRelationsResponse> _images = new();
     private List<KeyValuePair<Guid, string>> _imageContents = [];
-    private MudDataGrid<ImageRecord>? _dataGrid;
+    private MudDataGrid<ImageWithRelationsResponse>? _dataGrid;
 
-    private async Task<GridData<ImageRecord?>> GetImages(GridState<ImageRecord?> gridState)
+    private async Task<GridData<ImageWithRelationsResponse?>> GetImages(GridState<ImageWithRelationsResponse?> gridState)
     {
         if (!_images.Any())
         {
             await LoadImagesAsync();
         }
-        var result = new GridData<ImageRecord?>();
+
+        var result = new GridData<ImageWithRelationsResponse?>();
         var filteredItems = FilterImages(_images, _imageSearch).ToList();
         result.Items = filteredItems.Skip(gridState.Page * gridState.PageSize).Take(gridState.PageSize);
         result.TotalItems = filteredItems.Count;
@@ -73,25 +112,7 @@
 
     private async Task LoadImagesAsync()
     {
-        _images = [];
-
-        var imageResponses = await ImageService.GetImagesAsync();
-
-        foreach (var response in imageResponses)
-        {
-            _images.Add(new ImageRecord()
-            {
-                Id = response.Id,
-                InternalReference = response.InternalReference,
-                Height = response.Height,
-                Width = response.Width,
-                ContentHashSha1 = response.ContentHashSha1,
-                MimeType = response.MimeType,
-                LastChangeDateTimeUtc = response.LastChangeDateTimeUtc,
-                SizeInBytes = response.SizeInBytes,
-                IsDeleted = response.IsDeleted
-            });
-        }
+        _images = (await ImageService.GetImagesWithRelationsAsync()).ToList();
     }
 
     private async Task LoadImageSourcesAsync(IEnumerable<Guid> imageIds)
@@ -114,11 +135,13 @@
         _dataGrid?.ReloadServerData();
     }
 
-    private IEnumerable<ImageRecord> FilterImages(IEnumerable<ImageRecord> entries, string? searchString)
+    private IEnumerable<ImageWithRelationsResponse> FilterImages(IEnumerable<ImageWithRelationsResponse> entries, string? searchString)
     {
-        return string.IsNullOrEmpty(searchString) ? entries : entries.Where(entry => 
-        entry.InternalReference.ToLower().Contains(searchString.ToLower())
-            || entry.Id.ToString().ToLower().Contains(searchString.ToLower()));
+        return string.IsNullOrEmpty(searchString)
+            ? entries
+            : entries.Where(entry =>
+                entry.InternalReference.ToLower().Contains(searchString.ToLower())
+                || entry.Id.ToString().ToLower().Contains(searchString.ToLower()));
     }
 
     private async Task AddImage()
@@ -131,7 +154,7 @@
         _dataGrid?.ReloadServerData();
     }
 
-    private async Task UpdateImage(ImageRecord record)
+    private async Task UpdateImage(ImageWithRelationsResponse record)
     {
         var parameters = new DialogParameters<ImageDialog> { { x => x.Record, record } };
         var options = new DialogOptions { MaxWidth = MaxWidth.Large, FullWidth = true };
@@ -155,4 +178,5 @@
             Snackbar.Add("Error deleting image.", Severity.Error);
         }
     }
+
 }

--- a/src/Eurofurence.App.Backoffice/Pages/Images.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/Images.razor
@@ -103,7 +103,8 @@
     private IEnumerable<ImageRecord> FilterImages(IEnumerable<ImageRecord> entries, string? searchString)
     {
         return string.IsNullOrEmpty(searchString) ? entries : entries.Where(entry => 
-        entry.InternalReference.ToLower().Contains(searchString.ToLower()));
+        entry.InternalReference.ToLower().Contains(searchString.ToLower())
+            || entry.Id.ToString().ToLower().Contains(searchString.ToLower()));
     }
 
     private async Task AddImage()

--- a/src/Eurofurence.App.Backoffice/Pages/Images.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/Images.razor
@@ -4,6 +4,7 @@
 @using Eurofurence.App.Domain.Model.Images
 @using Eurofurence.App.Backoffice.Components
 @attribute [Authorize]
+@inject ISnackbar Snackbar
 @inject IImageService ImageService
 @inject IDialogService DialogService
 
@@ -52,14 +53,9 @@
 
 @code {
     private string? _imageSearch;
-    private IEnumerable<ImageRecord> _images = new List<ImageRecord>();
+    private List<ImageRecord> _images = new();
     private List<KeyValuePair<Guid, string>> _imageContents = [];
     private MudDataGrid<ImageRecord>? _dataGrid;
-
-    protected override async Task OnInitializedAsync()
-    {
-        await LoadImagesAsync();
-    }
 
     private async Task<GridData<ImageRecord?>> GetImages(GridState<ImageRecord?> gridState)
     {
@@ -77,7 +73,25 @@
 
     private async Task LoadImagesAsync()
     {
-        _images = await ImageService.GetImagesAsync();
+        _images = [];
+
+        var imageResponses = await ImageService.GetImagesAsync();
+
+        foreach (var response in imageResponses)
+        {
+            _images.Add(new ImageRecord()
+            {
+                Id = response.Id,
+                InternalReference = response.InternalReference,
+                Height = response.Height,
+                Width = response.Width,
+                ContentHashSha1 = response.ContentHashSha1,
+                MimeType = response.MimeType,
+                LastChangeDateTimeUtc = response.LastChangeDateTimeUtc,
+                SizeInBytes = response.SizeInBytes,
+                IsDeleted = response.IsDeleted
+            });
+        }
     }
 
     private async Task LoadImageSourcesAsync(IEnumerable<Guid> imageIds)
@@ -129,8 +143,16 @@
 
     private async Task DeleteImage(Guid id)
     {
-        await ImageService.DeleteImageAsync(id);
-        await LoadImagesAsync();
-        _dataGrid?.ReloadServerData();
+        var result = await ImageService.DeleteImageAsync(id);
+        if (result)
+        {
+            Snackbar.Add("Image deleted.", Severity.Success);
+            await LoadImagesAsync();
+            _dataGrid?.ReloadServerData();
+        }
+        else
+        {
+            Snackbar.Add("Error deleting image.", Severity.Error);
+        }
     }
 }

--- a/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
@@ -3,6 +3,7 @@
 @using Eurofurence.App.Domain.Model.Knowledge
 @using Microsoft.AspNetCore.Authorization
 @using Eurofurence.App.Backoffice.Components
+@using Eurofurence.App.Domain.Model.Images
 @using Markdig
 @attribute [Authorize]
 @inject IKnowledgeService KnowledgeService
@@ -129,7 +130,7 @@
     private string? _knowledgeEntrySearch;
     private KnowledgeGroupRecord? _selectedGroup;
     private IEnumerable<KnowledgeGroupRecord> _knowledgeGroups = new List<KnowledgeGroupRecord>();
-    private IEnumerable<KnowledgeEntryRecord> _knowledgeEntries = new List<KnowledgeEntryRecord>();
+    private IEnumerable<KnowledgeEntryResponse> _knowledgeEntries = new List<KnowledgeEntryResponse>();
     private List<KeyValuePair<Guid, List<string>>> _imageContents = [];
 
     protected override async Task OnInitializedAsync()
@@ -178,7 +179,7 @@
         Loading = false;
     }
 
-    private IEnumerable<KnowledgeEntryRecord> GetKnowledgeEntities()
+    private IEnumerable<KnowledgeEntryResponse> GetKnowledgeEntities()
     {
         if (_selectedGroup == null)
         {
@@ -188,7 +189,7 @@
         return FilterKnowledgeEntries(_knowledgeEntries, _knowledgeEntrySearch).Where(ke => ke.KnowledgeGroupId == _selectedGroup.Id);
     }
 
-    private IEnumerable<KnowledgeEntryRecord> FilterKnowledgeEntries(IEnumerable<KnowledgeEntryRecord> entries, string? searchString)
+    private IEnumerable<KnowledgeEntryResponse> FilterKnowledgeEntries(IEnumerable<KnowledgeEntryResponse> entries, string? searchString)
     {
         return string.IsNullOrEmpty(searchString) ? entries : entries.Where(entry => entry.Title.ToLower().Contains(searchString.ToLower()) || entry.Text.ToLower().Contains(searchString.ToLower()));
     }
@@ -210,8 +211,32 @@
         }
     }
 
-    private async Task UpdateKnowledgeEntry(KnowledgeEntryRecord record)
+    private async Task UpdateKnowledgeEntry(KnowledgeEntryResponse entity)
     {
+        var record = new KnowledgeEntryRecord()
+        {
+            Id = entity.Id,
+            Title = entity.Title,
+            Text = entity.Text,
+            KnowledgeGroupId = entity.KnowledgeGroupId,
+            LastChangeDateTimeUtc = entity.LastChangeDateTimeUtc,
+            Order = entity.Order,
+            Images = entity.Images.Select(image => new ImageRecord()
+            {
+                Id = image.Id,
+                InternalReference = image.InternalReference,
+                ContentHashSha1 = image.ContentHashSha1,
+                Height = image.Height,
+                Width = image.Width,
+                LastChangeDateTimeUtc = image.LastChangeDateTimeUtc,
+                MimeType = image.MimeType,
+                SizeInBytes = image.SizeInBytes,
+                IsDeleted = image.IsDeleted
+            }).ToList(),
+            Links = entity.Links,
+            IsDeleted = entity.IsDeleted
+        };
+
         var parameters = new DialogParameters<KnowledgeEntryDialog> { { x => x.Record, record } };
         var options = new DialogOptions() { MaxWidth = MaxWidth.Large, FullWidth = true };
 

--- a/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
@@ -109,9 +109,9 @@
                         }
                         else if (knowledgeEntry.Images.Count > 0)
                         {
-                            <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+                            <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
                         }
-                        
+
                     </MudCardContent>
                     <MudCardActions>
                         @foreach (var link in knowledgeEntry.Links)
@@ -129,8 +129,8 @@
     public bool Loading = true;
     private string? _knowledgeEntrySearch;
     private KnowledgeGroupRecord? _selectedGroup;
-    private IEnumerable<KnowledgeGroupRecord> _knowledgeGroups = new List<KnowledgeGroupRecord>();
-    private IEnumerable<KnowledgeEntryResponse> _knowledgeEntries = new List<KnowledgeEntryResponse>();
+    private List<KnowledgeGroupRecord> _knowledgeGroups = new List<KnowledgeGroupRecord>();
+    private List<KnowledgeEntryRecord> _knowledgeEntries = new List<KnowledgeEntryRecord>();
     private List<KeyValuePair<Guid, List<string>>> _imageContents = [];
 
     protected override async Task OnInitializedAsync()
@@ -143,14 +143,49 @@
     private async Task LoadKnowledgeEntries()
     {
         Loading = true;
-        _knowledgeEntries = (await KnowledgeService.GetKnowledgeEntriesAsync()).OrderBy(ke => ke.Order);
+        _knowledgeEntries = [];
+
+        var responses = (await KnowledgeService.GetKnowledgeEntriesAsync()).OrderBy(ke => ke.Order);
+        var imageResponses = await ImageService.GetImagesAsync();
+        foreach (var response in responses)
+        {
+            var record = new KnowledgeEntryRecord()
+            {
+                Id = response.Id,
+                KnowledgeGroupId = response.KnowledgeGroupId,
+                Title = response.Title,
+                Text = response.Text,
+                Order = response.Order,
+                LastChangeDateTimeUtc = response.LastChangeDateTimeUtc,
+                IsDeleted = response.IsDeleted,
+                Links = response.Links
+            };
+            foreach (var image in response.Images)
+            {
+                record.Images.Add(new ImageRecord()
+                {
+                    Id = image.Id,
+                    Height = image.Height,
+                    Width = image.Width,
+                    ContentHashSha1 = image.ContentHashSha1,
+                    InternalReference = image.InternalReference,
+                    MimeType = image.MimeType,
+                    SizeInBytes = image.SizeInBytes,
+                    LastChangeDateTimeUtc = image.LastChangeDateTimeUtc,
+                    IsDeleted = image.IsDeleted
+                });
+            }
+
+            _knowledgeEntries.Add(record);
+        }
+
         Loading = false;
     }
 
     private async Task LoadKnowledgeGroups()
     {
         Loading = true;
-        _knowledgeGroups = (await KnowledgeService.GetKnowledgeGroupsAsync()).OrderBy(kg => kg.Order);
+        _knowledgeGroups = (await KnowledgeService.GetKnowledgeGroupsAsync()).OrderBy(kg => kg.Order).ToList();
         Loading = false;
     }
 
@@ -158,7 +193,7 @@
     {
         Loading = true;
         _imageContents = [];
-        
+
         foreach (var knowledgeEntry in _knowledgeEntries)
         {
             StateHasChanged();
@@ -179,7 +214,7 @@
         Loading = false;
     }
 
-    private IEnumerable<KnowledgeEntryResponse> GetKnowledgeEntities()
+    private IEnumerable<KnowledgeEntryRecord> GetKnowledgeEntities()
     {
         if (_selectedGroup == null)
         {
@@ -189,7 +224,7 @@
         return FilterKnowledgeEntries(_knowledgeEntries, _knowledgeEntrySearch).Where(ke => ke.KnowledgeGroupId == _selectedGroup.Id);
     }
 
-    private IEnumerable<KnowledgeEntryResponse> FilterKnowledgeEntries(IEnumerable<KnowledgeEntryResponse> entries, string? searchString)
+    private IEnumerable<KnowledgeEntryRecord> FilterKnowledgeEntries(IEnumerable<KnowledgeEntryRecord> entries, string? searchString)
     {
         return string.IsNullOrEmpty(searchString) ? entries : entries.Where(entry => entry.Title.ToLower().Contains(searchString.ToLower()) || entry.Text.ToLower().Contains(searchString.ToLower()));
     }
@@ -211,32 +246,8 @@
         }
     }
 
-    private async Task UpdateKnowledgeEntry(KnowledgeEntryResponse entity)
+    private async Task UpdateKnowledgeEntry(KnowledgeEntryRecord record)
     {
-        var record = new KnowledgeEntryRecord()
-        {
-            Id = entity.Id,
-            Title = entity.Title,
-            Text = entity.Text,
-            KnowledgeGroupId = entity.KnowledgeGroupId,
-            LastChangeDateTimeUtc = entity.LastChangeDateTimeUtc,
-            Order = entity.Order,
-            Images = entity.Images.Select(image => new ImageRecord()
-            {
-                Id = image.Id,
-                InternalReference = image.InternalReference,
-                ContentHashSha1 = image.ContentHashSha1,
-                Height = image.Height,
-                Width = image.Width,
-                LastChangeDateTimeUtc = image.LastChangeDateTimeUtc,
-                MimeType = image.MimeType,
-                SizeInBytes = image.SizeInBytes,
-                IsDeleted = image.IsDeleted
-            }).ToList(),
-            Links = entity.Links,
-            IsDeleted = entity.IsDeleted
-        };
-
         var parameters = new DialogParameters<KnowledgeEntryDialog> { { x => x.Record, record } };
         var options = new DialogOptions() { MaxWidth = MaxWidth.Large, FullWidth = true };
 

--- a/src/Eurofurence.App.Backoffice/Program.cs
+++ b/src/Eurofurence.App.Backoffice/Program.cs
@@ -13,6 +13,8 @@ builder.Services.AddMudServices();
 
 builder.Services.AddScoped<IKnowledgeService, KnowledgeService>();
 builder.Services.AddScoped<IImageService, ImageService>();
+builder.Services.AddScoped<IArtistAlleyService, ArtistAlleyService>();
+builder.Services.AddScoped<IFursuitService, FursuitService>();
 
 builder.Services.AddScoped<TokenAuthorizationMessageHandler>();
 builder.Services.AddHttpClient("api", options =>

--- a/src/Eurofurence.App.Backoffice/Program.cs
+++ b/src/Eurofurence.App.Backoffice/Program.cs
@@ -15,6 +15,7 @@ builder.Services.AddScoped<IKnowledgeService, KnowledgeService>();
 builder.Services.AddScoped<IImageService, ImageService>();
 builder.Services.AddScoped<IArtistAlleyService, ArtistAlleyService>();
 builder.Services.AddScoped<IFursuitService, FursuitService>();
+builder.Services.AddScoped<IDealerService, DealerService>();
 
 builder.Services.AddScoped<TokenAuthorizationMessageHandler>();
 builder.Services.AddHttpClient("api", options =>

--- a/src/Eurofurence.App.Backoffice/Services/ArtistAlleyService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/ArtistAlleyService.cs
@@ -11,7 +11,7 @@ namespace Eurofurence.App.Backoffice.Services
         {
             var options = new JsonSerializerOptions();
             options.Converters.Add(new JsonStringEnumConverter());
-            return (await http.GetFromJsonAsync<TableRegistrationResponse[]>("ArtistsAlley/TableRegistrations", options))?.Where(ke => ke.IsDeleted != 1).ToArray() ?? [];
+            return (await http.GetFromJsonAsync<TableRegistrationResponse[]>("ArtistsAlley", options))?.Where(ke => ke.IsDeleted != 1).ToArray() ?? [];
         }
     }
 }

--- a/src/Eurofurence.App.Backoffice/Services/ArtistAlleyService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/ArtistAlleyService.cs
@@ -1,0 +1,17 @@
+﻿using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json;
+using Eurofurence.App.Domain.Model.ArtistsAlley;
+
+namespace Eurofurence.App.Backoffice.Services
+{
+    public class ArtistAlleyService(HttpClient http) : IArtistAlleyService
+    {
+        public async Task<TableRegistrationResponse[]> GetTableRegistrationsAsync()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new JsonStringEnumConverter());
+            return (await http.GetFromJsonAsync<TableRegistrationResponse[]>("ArtistsAlley/TableRegistrations", options))?.Where(ke => ke.IsDeleted != 1).ToArray() ?? [];
+        }
+    }
+}

--- a/src/Eurofurence.App.Backoffice/Services/DealerService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/DealerService.cs
@@ -1,0 +1,17 @@
+﻿using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json;
+using Eurofurence.App.Domain.Model.Dealers;
+
+namespace Eurofurence.App.Backoffice.Services
+{
+    public class DealerService(HttpClient http) : IDealerService
+    {
+        public async Task<DealerRecord[]> GetDealersAsync()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new JsonStringEnumConverter());
+            return (await http.GetFromJsonAsync<DealerRecord[]>("Dealers", options))?.Where(ke => ke.IsDeleted != 1).ToArray() ?? [];
+        }
+    }
+}

--- a/src/Eurofurence.App.Backoffice/Services/FursuitService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/FursuitService.cs
@@ -1,0 +1,17 @@
+﻿using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json;
+using Eurofurence.App.Domain.Model.Fursuits;
+
+namespace Eurofurence.App.Backoffice.Services
+{
+    public class FursuitService(HttpClient http) : IFursuitService
+    {
+        public async Task<FursuitBadgeResponse[]> GetFursuitBadgesAsync()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new JsonStringEnumConverter());
+            return (await http.GetFromJsonAsync<FursuitBadgeResponse[]>("Fursuits/Badges", options))?.Where(ke => ke.IsDeleted != 1).ToArray() ?? [];
+        }
+    }
+}

--- a/src/Eurofurence.App.Backoffice/Services/IArtistAlleyService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/IArtistAlleyService.cs
@@ -1,0 +1,9 @@
+﻿using Eurofurence.App.Domain.Model.ArtistsAlley;
+
+namespace Eurofurence.App.Backoffice.Services
+{
+    public interface IArtistAlleyService
+    {
+        public Task<TableRegistrationResponse[]> GetTableRegistrationsAsync();
+    }
+}

--- a/src/Eurofurence.App.Backoffice/Services/IDealerService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/IDealerService.cs
@@ -1,0 +1,9 @@
+﻿using Eurofurence.App.Domain.Model.Dealers;
+
+namespace Eurofurence.App.Backoffice.Services
+{
+    public interface IDealerService
+    {
+        public Task<DealerRecord[]> GetDealersAsync();
+    }
+}

--- a/src/Eurofurence.App.Backoffice/Services/IFursuitService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/IFursuitService.cs
@@ -1,0 +1,9 @@
+﻿using Eurofurence.App.Domain.Model.Fursuits;
+
+namespace Eurofurence.App.Backoffice.Services
+{
+    public interface IFursuitService
+    {
+        public Task<FursuitBadgeResponse[]> GetFursuitBadgesAsync();
+    }
+}

--- a/src/Eurofurence.App.Backoffice/Services/IImageService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/IImageService.cs
@@ -5,10 +5,10 @@ namespace Eurofurence.App.Backoffice.Services
 {
     public interface IImageService
     {
-        public Task<ImageRecord[]> GetImagesAsync();
+        public Task<ImageResponse[]> GetImagesAsync();
         public Task<string> GetImageContentAsync(Guid id);
-        public Task<ImageRecord?> PutImageAsync(Guid id, IBrowserFile file);
-        public Task<ImageRecord?> PostImageAsync(IBrowserFile file);
+        public Task<ImageResponse?> PutImageAsync(Guid id, IBrowserFile file);
+        public Task<ImageResponse?> PostImageAsync(IBrowserFile file);
         public Task<bool> DeleteImageAsync(Guid id);
     }
 }

--- a/src/Eurofurence.App.Backoffice/Services/IImageService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/IImageService.cs
@@ -6,6 +6,7 @@ namespace Eurofurence.App.Backoffice.Services
     public interface IImageService
     {
         public Task<ImageResponse[]> GetImagesAsync();
+        public Task<ImageWithRelationsResponse[]> GetImagesWithRelationsAsync();
         public Task<string> GetImageContentAsync(Guid id);
         public Task<ImageResponse?> PutImageAsync(Guid id, IBrowserFile file);
         public Task<ImageResponse?> PostImageAsync(IBrowserFile file);

--- a/src/Eurofurence.App.Backoffice/Services/IKnowledgeService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/IKnowledgeService.cs
@@ -4,7 +4,7 @@ namespace Eurofurence.App.Backoffice.Services
 {
     public interface IKnowledgeService
     {
-        public Task<KnowledgeEntryRecord[]> GetKnowledgeEntriesAsync();
+        public Task<KnowledgeEntryResponse[]> GetKnowledgeEntriesAsync();
         public Task<bool> PutKnowledgeEntryAsync(Guid id, KnowledgeEntryRequest record);
         public Task<bool> PostKnowledgeEntryAsync(KnowledgeEntryRequest record);
         public Task<bool> DeleteKnowledgeEntryAsync(Guid id);

--- a/src/Eurofurence.App.Backoffice/Services/ImageService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/ImageService.cs
@@ -14,6 +14,11 @@ namespace Eurofurence.App.Backoffice.Services
             return (await http.GetFromJsonAsync<ImageResponse[]>("images"))?.Where(ke => ke.IsDeleted != 1).ToArray() ?? [];
         }
 
+        public async Task<ImageWithRelationsResponse[]> GetImagesWithRelationsAsync()
+        {
+            return (await http.GetFromJsonAsync<ImageWithRelationsResponse[]>("images/with-relations"))?.Where(ke => ke.IsDeleted != 1).ToArray() ?? [];
+        }
+
         public async Task<string> GetImageContentAsync(Guid id)
         {
             try

--- a/src/Eurofurence.App.Backoffice/Services/ImageService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/ImageService.cs
@@ -9,9 +9,9 @@ namespace Eurofurence.App.Backoffice.Services
 {
     public class ImageService(HttpClient http) : IImageService
     {
-        public async Task<ImageRecord[]> GetImagesAsync()
+        public async Task<ImageResponse[]> GetImagesAsync()
         {
-            return (await http.GetFromJsonAsync<ImageRecord[]>("images"))?.Where(ke => ke.IsDeleted != 1).ToArray() ?? [];
+            return (await http.GetFromJsonAsync<ImageResponse[]>("images"))?.Where(ke => ke.IsDeleted != 1).ToArray() ?? [];
         }
 
         public async Task<string> GetImageContentAsync(Guid id)
@@ -26,7 +26,7 @@ namespace Eurofurence.App.Backoffice.Services
             }
         }
 
-        public async Task<ImageRecord?> PutImageAsync(Guid id, IBrowserFile file)
+        public async Task<ImageResponse?> PutImageAsync(Guid id, IBrowserFile file)
         {
             using (var content = new MultipartFormDataContent())
             {
@@ -38,11 +38,11 @@ namespace Eurofurence.App.Backoffice.Services
                 {
                     return null;
                 }
-                return JsonSerializer.Deserialize<ImageRecord>(await response.Content.ReadAsStreamAsync());
+                return JsonSerializer.Deserialize<ImageResponse>(await response.Content.ReadAsStreamAsync());
             }
         }
 
-        public async Task<ImageRecord?> PostImageAsync(IBrowserFile file)
+        public async Task<ImageResponse?> PostImageAsync(IBrowserFile file)
         {
             using (var content = new MultipartFormDataContent())
             {
@@ -54,7 +54,7 @@ namespace Eurofurence.App.Backoffice.Services
                 {
                     return null;
                 }
-                return JsonSerializer.Deserialize<ImageRecord>(await response.Content.ReadAsStreamAsync());
+                return JsonSerializer.Deserialize<ImageResponse>(await response.Content.ReadAsStreamAsync());
             }
         }
 

--- a/src/Eurofurence.App.Backoffice/Services/KnowledgeService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/KnowledgeService.cs
@@ -7,11 +7,11 @@ namespace Eurofurence.App.Backoffice.Services
 {
     public class KnowledgeService(HttpClient http) : IKnowledgeService
     {
-        public async Task<KnowledgeEntryRecord[]> GetKnowledgeEntriesAsync()
+        public async Task<KnowledgeEntryResponse[]> GetKnowledgeEntriesAsync()
         {
             var options = new JsonSerializerOptions();
             options.Converters.Add(new JsonStringEnumConverter());
-            return (await http.GetFromJsonAsync<KnowledgeEntryRecord[]>("knowledgeEntries", options))?.Where(ke => ke.IsDeleted != 1).ToArray() ?? [];
+            return (await http.GetFromJsonAsync<KnowledgeEntryResponse[]>("knowledgeEntries", options))?.Where(ke => ke.IsDeleted != 1).ToArray() ?? [];
         }
 
         public async Task<bool> PutKnowledgeEntryAsync(Guid id, KnowledgeEntryRequest record)

--- a/src/Eurofurence.App.Domain.Model/ArtistsAlley/TableRegistrationRecord.cs
+++ b/src/Eurofurence.App.Domain.Model/ArtistsAlley/TableRegistrationRecord.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 using Eurofurence.App.Domain.Model.Images;
 
@@ -43,6 +44,9 @@ namespace Eurofurence.App.Domain.Model.ArtistsAlley
 
         [DataMember]
         public string Location { get; set; }
+
+        [DataMember]
+        public Guid? ImageId { get; set; }
 
         [DataMember]
         public ImageRecord Image { get; set; }

--- a/src/Eurofurence.App.Domain.Model/ArtistsAlley/TableRegistrationResponse.cs
+++ b/src/Eurofurence.App.Domain.Model/ArtistsAlley/TableRegistrationResponse.cs
@@ -1,0 +1,42 @@
+﻿using Eurofurence.App.Domain.Model.Images;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Eurofurence.App.Domain.Model.ArtistsAlley
+{
+    public class TableRegistrationResponse : EntityBase
+    {
+        [DataMember]
+        public DateTime CreatedDateTimeUtc { get; set; }
+
+        [DataMember]
+        public string OwnerUid { get; set; }
+
+        [DataMember]
+        public string DisplayName { get; set; }
+
+        [DataMember]
+        public string WebsiteUrl { get; set; }
+
+        [DataMember]
+        public string ShortDescription { get; set; }
+
+        [DataMember]
+        public string TelegramHandle { get; set; }
+
+        [DataMember]
+        public string Location { get; set; }
+
+        [DataMember]
+        public ImageResponse Image { get; set; }
+
+        [DataMember]
+        public TableRegistrationRecord.RegistrationStateEnum State { get; set; }
+
+        [IgnoreDataMember] public List<TableRegistrationRecord.StateChangeRecord> StateChangeLog { get; set; } = new();
+    }
+}

--- a/src/Eurofurence.App.Domain.Model/Dealers/DealerRecord.cs
+++ b/src/Eurofurence.App.Domain.Model/Dealers/DealerRecord.cs
@@ -3,6 +3,8 @@ using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 using Eurofurence.App.Domain.Model.Fragments;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using Eurofurence.App.Domain.Model.Images;
 
 namespace Eurofurence.App.Domain.Model.Dealers
 {
@@ -111,6 +113,9 @@ namespace Eurofurence.App.Domain.Model.Dealers
         [DataMember]
         public Guid? ArtistThumbnailImageId { get; set; }
 
+        [DataMember]
+        public ImageRecord ArtistThumbnailImage { get; set; }
+
         /// <summary>
         /// **(pba)** ImageId of the artist image (any aspect ratio) that represents the dealer.
         /// Usually a personal photo / logo / badge, or a high-res version of the thumbnail image.
@@ -118,11 +123,17 @@ namespace Eurofurence.App.Domain.Model.Dealers
         [DataMember]
         public Guid? ArtistImageId { get; set; }
 
+        [DataMember]
+        public ImageRecord ArtistImage { get; set; }
+
         /// <summary>
         /// **(pba)** ImageId of an art/merchandise sample sold/offered by the dealer.
         /// </summary>
         [DataMember]
         public Guid? ArtPreviewImageId { get; set; }
+
+        [DataMember]
+        public ImageRecord ArtPreviewImage { get; set; }
 
         /// <summary>
         /// Flag indicating whether the dealer is located at the after dark dealers den.

--- a/src/Eurofurence.App.Domain.Model/Dealers/DealerRequest.cs
+++ b/src/Eurofurence.App.Domain.Model/Dealers/DealerRequest.cs
@@ -1,22 +1,24 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
-using System.Runtime.Serialization;
-using Eurofurence.App.Domain.Model.Fragments;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
+﻿using Eurofurence.App.Domain.Model.Fragments;
 using Eurofurence.App.Domain.Model.Images;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace Eurofurence.App.Domain.Model.Dealers
 {
     /// <summary>
-    /// This record represents a 'dealer' that is offering goods/services at the dealers den.
+    /// This request represents a 'dealer' that is offering goods/services at the dealers den.
     /// All dealers are represented and registered by participating attendees.
     /// 
     /// Properties marked with **(pba)** indicate that its value or the content referenced
     /// by it is provided directly by the attendee during or after dealer registration.
     /// </summary>
     [DataContract]
-    public class DealerRecord : EntityBase
+    public class DealerRequest : EntityBase
     {
         /// <summary>
         /// Registration number (as on badge) of the attendee that acts on behalf/represents this dealer.
@@ -113,9 +115,6 @@ namespace Eurofurence.App.Domain.Model.Dealers
         [DataMember]
         public Guid? ArtistThumbnailImageId { get; set; }
 
-        [DataMember]
-        public ImageRecord ArtistThumbnailImage { get; set; }
-
         /// <summary>
         /// **(pba)** ImageId of the artist image (any aspect ratio) that represents the dealer.
         /// Usually a personal photo / logo / badge, or a high-res version of the thumbnail image.
@@ -123,17 +122,11 @@ namespace Eurofurence.App.Domain.Model.Dealers
         [DataMember]
         public Guid? ArtistImageId { get; set; }
 
-        [DataMember]
-        public ImageRecord ArtistImage { get; set; }
-
         /// <summary>
         /// **(pba)** ImageId of an art/merchandise sample sold/offered by the dealer.
         /// </summary>
         [DataMember]
         public Guid? ArtPreviewImageId { get; set; }
-
-        [DataMember]
-        public ImageRecord ArtPreviewImage { get; set; }
 
         /// <summary>
         /// Flag indicating whether the dealer is located at the after dark dealers den.

--- a/src/Eurofurence.App.Domain.Model/Events/EventRecord.cs
+++ b/src/Eurofurence.App.Domain.Model/Events/EventRecord.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Eurofurence.App.Domain.Model.Images;
+using System;
 using System.Runtime.Serialization;
 
 namespace Eurofurence.App.Domain.Model.Events
@@ -63,12 +64,18 @@ namespace Eurofurence.App.Domain.Model.Events
         [DataMember]
         public Guid? BannerImageId { get; set; }
 
+        [DataMember]
+        public ImageRecord BannerImage { get; set; }
+
         /// <summary>
         ///     If set, refers to an image of any aspect ratio that should be used where enough
         ///     vertical space is available (e.G. event detail).
         /// </summary>
         [DataMember]
         public Guid? PosterImageId { get; set; }
+
+        [DataMember]
+        public ImageRecord PosterImage { get; set; }
 
         [DataMember]
         public string[] Tags { get; set; }

--- a/src/Eurofurence.App.Domain.Model/Fursuits/FursuitBadgeResponse.cs
+++ b/src/Eurofurence.App.Domain.Model/Fursuits/FursuitBadgeResponse.cs
@@ -1,0 +1,36 @@
+﻿using Eurofurence.App.Domain.Model.Images;
+using System;
+using System.Runtime.Serialization;
+
+namespace Eurofurence.App.Domain.Model.Fursuits
+{
+    [DataContract]
+    public class FursuitBadgeResponse : EntityBase
+    {
+        [DataMember]
+        public string ExternalReference { get; set; }
+
+        [DataMember]
+        public string OwnerUid { get; set; }
+
+        [DataMember]
+        public string Name { get; set; }
+
+        [DataMember]
+        public string WornBy { get; set; }
+
+        [DataMember]
+        public string Species { get; set; }
+
+        [DataMember]
+        public string Gender { get; set; }
+
+        [DataMember]
+        public bool IsPublic { get; set; }
+
+        public string CollectionCode { get; set; }
+
+        public Guid? ImageId { get; set; }
+        public ImageResponse Image { get; set; }
+    }
+}

--- a/src/Eurofurence.App.Domain.Model/Fursuits/FursuitParticipationInfoResponse.cs
+++ b/src/Eurofurence.App.Domain.Model/Fursuits/FursuitParticipationInfoResponse.cs
@@ -1,0 +1,11 @@
+﻿using Eurofurence.App.Domain.Model.Fursuits.CollectingGame;
+
+namespace Eurofurence.App.Domain.Model.Fursuits
+{
+    public class FursuitParticipationInfoResponse
+    {
+        public FursuitBadgeResponse Badge { get; set; }
+        public bool IsParticipating { get; set; }
+        public FursuitParticipationRecord Participation { get; set; }
+    }
+}

--- a/src/Eurofurence.App.Domain.Model/Images/ImageRecord.cs
+++ b/src/Eurofurence.App.Domain.Model/Images/ImageRecord.cs
@@ -34,8 +34,8 @@ namespace Eurofurence.App.Domain.Model.Images
         [DataMember]
         public string ContentHashSha1 { get; set; }
 
-        public List<FursuitBadgeRecord> FursuitBadges { get; set; } = new();
-        public List<TableRegistrationRecord> TableRegistrations { get; set; } = new();
-        public List<MapRecord> Maps { get; set; } = new();
+        public virtual List<FursuitBadgeRecord> FursuitBadges { get; set; } = new();
+        public virtual List<TableRegistrationRecord> TableRegistrations { get; set; } = new();
+        public virtual List<MapRecord> Maps { get; set; } = new();
     }
 }

--- a/src/Eurofurence.App.Domain.Model/Images/ImageRecord.cs
+++ b/src/Eurofurence.App.Domain.Model/Images/ImageRecord.cs
@@ -2,7 +2,10 @@
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 using Eurofurence.App.Domain.Model.ArtistsAlley;
+using Eurofurence.App.Domain.Model.Dealers;
+using Eurofurence.App.Domain.Model.Events;
 using Eurofurence.App.Domain.Model.Fursuits;
+using Eurofurence.App.Domain.Model.Knowledge;
 using Eurofurence.App.Domain.Model.Maps;
 
 namespace Eurofurence.App.Domain.Model.Images
@@ -34,8 +37,22 @@ namespace Eurofurence.App.Domain.Model.Images
         [DataMember]
         public string ContentHashSha1 { get; set; }
 
+        public virtual List<KnowledgeEntryRecord> KnowledgeEntries { get; set; } = new();
+
         public virtual List<FursuitBadgeRecord> FursuitBadges { get; set; } = new();
+
         public virtual List<TableRegistrationRecord> TableRegistrations { get; set; } = new();
+
         public virtual List<MapRecord> Maps { get; set; } = new();
+
+        public virtual List<EventRecord> EventBanners { get; set; } = new();
+
+        public virtual List<EventRecord> EventPosters { get; set; } = new();
+
+        public virtual List<DealerRecord> DealerArtists { get; set; } = new();
+
+        public virtual List<DealerRecord> DealerArtistThumbnails { get; set; } = new();
+
+        public virtual List<DealerRecord> DealerArtPreviews { get; set; } = new();
     }
 }

--- a/src/Eurofurence.App.Domain.Model/Images/ImageResponse.cs
+++ b/src/Eurofurence.App.Domain.Model/Images/ImageResponse.cs
@@ -1,0 +1,26 @@
+﻿using System.Runtime.Serialization;
+
+namespace Eurofurence.App.Domain.Model.Images
+{
+    [DataContract]
+    public class ImageResponse : EntityBase
+    {
+        [DataMember]
+        public string InternalReference { get; set; }
+
+        [DataMember]
+        public int Width { get; set; }
+
+        [DataMember]
+        public int Height { get; set; }
+
+        [DataMember]
+        public long SizeInBytes { get; set; }
+
+        [DataMember]
+        public string MimeType { get; set; }
+
+        [DataMember]
+        public string ContentHashSha1 { get; set; }
+    }
+}

--- a/src/Eurofurence.App.Domain.Model/Images/ImageWithRelationsResponse.cs
+++ b/src/Eurofurence.App.Domain.Model/Images/ImageWithRelationsResponse.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Eurofurence.App.Domain.Model.Images
+{
+    [DataContract]
+    public class ImageWithRelationsResponse : ImageResponse
+    {
+        [DataMember]
+        public List<Guid> KnowledgeEntryIds { get; set; } = new();
+
+        [DataMember]
+        public List<Guid> FursuitBadgeIds { get; set; } = new();
+
+        [DataMember]
+        public List<Guid> TableRegistrationIds { get; set; } = new();
+
+        [DataMember] 
+        public List<Guid> MapIds { get; set; } = new();
+
+        [DataMember]
+        public List<Guid> EventBannerIds { get; set; } = new();
+
+        [DataMember]
+        public List<Guid> EventPosterIds { get; set; } = new();
+
+        [DataMember]
+        public List<Guid> DealerArtistIds { get; set; } = new();
+
+        [DataMember]
+        public List<Guid> DealerArtistThumbnailIds { get; set; } = new();
+
+        [DataMember]
+        public List<Guid> DealerArtPreviewIds { get; set; } = new();
+    }
+}

--- a/src/Eurofurence.App.Domain.Model/Knowledge/KnowledgeEntryResponse.cs
+++ b/src/Eurofurence.App.Domain.Model/Knowledge/KnowledgeEntryResponse.cs
@@ -1,12 +1,13 @@
-﻿using System;
+﻿using Eurofurence.App.Domain.Model.Fragments;
+using Eurofurence.App.Domain.Model.Images;
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
-using Eurofurence.App.Domain.Model.Fragments;
 
 namespace Eurofurence.App.Domain.Model.Knowledge
 {
     [DataContract]
-    public class KnowledgeEntryRequest
+    public class KnowledgeEntryResponse : EntityBase
     {
         [DataMember]
         public Guid KnowledgeGroupId { get; set; }
@@ -21,9 +22,9 @@ namespace Eurofurence.App.Domain.Model.Knowledge
         public int Order { get; set; }
 
         [DataMember]
-        public List<LinkFragment> Links { get; set; } = new();
+        public virtual List<LinkFragment> Links { get; set; } = new();
 
         [DataMember]
-        public List<Guid> ImageIds { get; set; } = new();
+        public virtual List<ImageResponse> Images { get; set; } = new();
     }
 }

--- a/src/Eurofurence.App.Domain.Model/Maps/MapEntryRequest.cs
+++ b/src/Eurofurence.App.Domain.Model/Maps/MapEntryRequest.cs
@@ -1,16 +1,12 @@
 ﻿using Eurofurence.App.Domain.Model.Fragments;
-using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace Eurofurence.App.Domain.Model.Maps
 {
     [DataContract]
-    public class MapEntryResponse
+    public class MapEntryRequest
     {
-        [DataMember]
-        public Guid Id { get; set; }
-
         /// <summary>
         ///     "X" coordinate of the *center* of a *circular area*, expressed in pixels.
         /// </summary>

--- a/src/Eurofurence.App.Domain.Model/Maps/MapEntryRequest.cs
+++ b/src/Eurofurence.App.Domain.Model/Maps/MapEntryRequest.cs
@@ -1,4 +1,5 @@
-﻿using Eurofurence.App.Domain.Model.Fragments;
+﻿using System;
+using Eurofurence.App.Domain.Model.Fragments;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -7,6 +8,7 @@ namespace Eurofurence.App.Domain.Model.Maps
     [DataContract]
     public class MapEntryRequest
     {
+        public Guid Id { get; set; }
         /// <summary>
         ///     "X" coordinate of the *center* of a *circular area*, expressed in pixels.
         /// </summary>

--- a/src/Eurofurence.App.Domain.Model/Maps/MapEntryResponse.cs
+++ b/src/Eurofurence.App.Domain.Model/Maps/MapEntryResponse.cs
@@ -1,0 +1,38 @@
+﻿using Eurofurence.App.Domain.Model.Fragments;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Eurofurence.App.Domain.Model.Maps
+{
+    [DataContract]
+    public class MapEntryResponse
+    {
+        [DataMember]
+        public Guid Id { get; set; }
+
+        /// <summary>
+        ///     "X" coordinate of the *center* of a *circular area*, expressed in pixels.
+        /// </summary>
+        [DataMember]
+        public int X { get; set; }
+
+        /// <summary>
+        ///     "Y" coordinate of the *center* of a *circular area*, expressed in pixels.
+        /// </summary>
+        [DataMember]
+        public int Y { get; set; }
+
+        /// <summary>
+        ///     "Radius" of a *circular area* (the center of which described with X and Y), expressed in pixels.
+        /// </summary>
+        [DataMember]
+        public int TapRadius { get; set; }
+
+        [DataMember]
+        public List<LinkFragment> Links { get; set; } = new();
+
+        [IgnoreDataMember]
+        public virtual MapResponse Map { get; set; }
+    }
+}

--- a/src/Eurofurence.App.Domain.Model/Maps/MapRecord.cs
+++ b/src/Eurofurence.App.Domain.Model/Maps/MapRecord.cs
@@ -25,8 +25,7 @@ namespace Eurofurence.App.Domain.Model.Maps
         public IList<MapEntryRecord> Entries { get; set; } = new List<MapEntryRecord>();
 
         [DataMember]
-        [Required]
-        public Guid ImageId { get; set; }
+        public Guid? ImageId { get; set; }
 
         [IgnoreDataMember]
         public virtual ImageRecord Image { get; set; }

--- a/src/Eurofurence.App.Domain.Model/Maps/MapRequest.cs
+++ b/src/Eurofurence.App.Domain.Model/Maps/MapRequest.cs
@@ -8,6 +8,8 @@ namespace Eurofurence.App.Domain.Model.Maps
     [DataContract]
     public class MapRequest
     {
+        public Guid Id { get; set; }
+
         [DataMember]
         [Required]
         public string Description { get; set; }

--- a/src/Eurofurence.App.Domain.Model/Maps/MapRequest.cs
+++ b/src/Eurofurence.App.Domain.Model/Maps/MapRequest.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace Eurofurence.App.Domain.Model.Maps
+{
+    [DataContract]
+    public class MapRequest
+    {
+        [DataMember]
+        [Required]
+        public string Description { get; set; }
+
+        [Required]
+        [DataMember]
+        public int Order { get; set; }
+
+        [DataMember]
+        [Required]
+        public bool IsBrowseable { get; set; }
+
+        [DataMember]
+        public List<MapEntryRequest> Entries { get; set; } = new();
+
+        [DataMember]
+        [Required]
+        public Guid ImageId { get; set; }
+    }
+}

--- a/src/Eurofurence.App.Domain.Model/Maps/MapResponse.cs
+++ b/src/Eurofurence.App.Domain.Model/Maps/MapResponse.cs
@@ -1,0 +1,29 @@
+﻿using Eurofurence.App.Domain.Model.Images;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Eurofurence.App.Domain.Model.Maps
+{
+    [DataContract]
+    public class MapResponse : EntityBase
+    {
+        [DataMember]
+        public string Description { get; set; }
+
+        [DataMember]
+        public int Order { get; set; }
+
+        [DataMember]
+        public bool IsBrowseable { get; set; }
+
+        [DataMember]
+        public List<MapEntryResponse> Entries { get; set; } = new();
+
+        [DataMember]
+        public Guid ImageId { get; set; }
+
+        [IgnoreDataMember]
+        public virtual ImageResponse Image { get; set; }
+    }
+}

--- a/src/Eurofurence.App.Infrastructure.EntityFramework/AppDbContext.cs
+++ b/src/Eurofurence.App.Infrastructure.EntityFramework/AppDbContext.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Eurofurence.App.Domain.Model.Announcements;
+﻿using Eurofurence.App.Domain.Model.Announcements;
 using Eurofurence.App.Domain.Model.ArtistsAlley;
 using Eurofurence.App.Domain.Model.ArtShow;
 using Eurofurence.App.Domain.Model.CollectionGame;
@@ -20,8 +17,6 @@ using Eurofurence.App.Domain.Model.Security;
 using Eurofurence.App.Domain.Model.Sync;
 using Eurofurence.App.Domain.Model.Telegram;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Eurofurence.App.Infrastructure.EntityFramework
 {
@@ -73,6 +68,31 @@ namespace Eurofurence.App.Infrastructure.EntityFramework
 
             modelBuilder.Entity<DealerRecord>().Property(x => x.Keywords)
                 .HasColumnType("json");
+
+            modelBuilder.Entity<ImageRecord>()
+                .HasMany(i => i.EventPosters)
+                .WithOne(e => e.PosterImage)
+                .HasForeignKey(e => e.PosterImageId);
+
+            modelBuilder.Entity<ImageRecord>()
+                .HasMany(i => i.EventBanners)
+                .WithOne(e => e.BannerImage)
+                .HasForeignKey(e => e.BannerImageId);
+
+            modelBuilder.Entity<ImageRecord>()
+                .HasMany(i => i.DealerArtists)
+                .WithOne(d => d.ArtistImage)
+                .HasForeignKey(d => d.ArtistImageId);
+
+            modelBuilder.Entity<ImageRecord>()
+                .HasMany(i => i.DealerArtPreviews)
+                .WithOne(d => d.ArtPreviewImage)
+                .HasForeignKey(d => d.ArtPreviewImageId);
+
+            modelBuilder.Entity<ImageRecord>()
+                .HasMany(i => i.DealerArtistThumbnails)
+                .WithOne(d => d.ArtistThumbnailImage)
+                .HasForeignKey(d => d.ArtistThumbnailImageId);
         }
     }
 }

--- a/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240801174007_ReworkedImageRelations.Designer.cs
+++ b/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240801174007_ReworkedImageRelations.Designer.cs
@@ -4,6 +4,7 @@ using Eurofurence.App.Infrastructure.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Eurofurence.App.Infrastructure.EntityFramework.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240801174007_ReworkedImageRelations")]
+    partial class ReworkedImageRelations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240801174007_ReworkedImageRelations.cs
+++ b/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240801174007_ReworkedImageRelations.cs
@@ -1,0 +1,273 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eurofurence.App.Infrastructure.EntityFramework.Migrations
+{
+    /// <inheritdoc />
+    public partial class ReworkedImageRelations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Images_KnowledgeEntries_KnowledgeEntryRecordId",
+                table: "Images");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MapEntries_Maps_MapId",
+                table: "MapEntries");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Maps_Images_ImageId",
+                table: "Maps");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Images_KnowledgeEntryRecordId",
+                table: "Images");
+
+            migrationBuilder.DropColumn(
+                name: "KnowledgeEntryRecordId",
+                table: "Images");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ImageId",
+                table: "Maps",
+                type: "char(36)",
+                nullable: true,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "char(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "MapId",
+                table: "MapEntries",
+                type: "char(36)",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "char(36)",
+                oldNullable: true)
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.CreateTable(
+                name: "ImageRecordKnowledgeEntryRecord",
+                columns: table => new
+                {
+                    ImagesId = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                    KnowledgeEntriesId = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ImageRecordKnowledgeEntryRecord", x => new { x.ImagesId, x.KnowledgeEntriesId });
+                    table.ForeignKey(
+                        name: "FK_ImageRecordKnowledgeEntryRecord_Images_ImagesId",
+                        column: x => x.ImagesId,
+                        principalTable: "Images",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ImageRecordKnowledgeEntryRecord_KnowledgeEntries_KnowledgeEn~",
+                        column: x => x.KnowledgeEntriesId,
+                        principalTable: "KnowledgeEntries",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Events_BannerImageId",
+                table: "Events",
+                column: "BannerImageId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Events_PosterImageId",
+                table: "Events",
+                column: "PosterImageId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Dealers_ArtistImageId",
+                table: "Dealers",
+                column: "ArtistImageId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Dealers_ArtistThumbnailImageId",
+                table: "Dealers",
+                column: "ArtistThumbnailImageId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Dealers_ArtPreviewImageId",
+                table: "Dealers",
+                column: "ArtPreviewImageId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ImageRecordKnowledgeEntryRecord_KnowledgeEntriesId",
+                table: "ImageRecordKnowledgeEntryRecord",
+                column: "KnowledgeEntriesId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Dealers_Images_ArtPreviewImageId",
+                table: "Dealers",
+                column: "ArtPreviewImageId",
+                principalTable: "Images",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Dealers_Images_ArtistImageId",
+                table: "Dealers",
+                column: "ArtistImageId",
+                principalTable: "Images",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Dealers_Images_ArtistThumbnailImageId",
+                table: "Dealers",
+                column: "ArtistThumbnailImageId",
+                principalTable: "Images",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Events_Images_BannerImageId",
+                table: "Events",
+                column: "BannerImageId",
+                principalTable: "Images",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Events_Images_PosterImageId",
+                table: "Events",
+                column: "PosterImageId",
+                principalTable: "Images",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MapEntries_Maps_MapId",
+                table: "MapEntries",
+                column: "MapId",
+                principalTable: "Maps",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Maps_Images_ImageId",
+                table: "Maps",
+                column: "ImageId",
+                principalTable: "Images",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Dealers_Images_ArtPreviewImageId",
+                table: "Dealers");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Dealers_Images_ArtistImageId",
+                table: "Dealers");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Dealers_Images_ArtistThumbnailImageId",
+                table: "Dealers");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Events_Images_BannerImageId",
+                table: "Events");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Events_Images_PosterImageId",
+                table: "Events");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MapEntries_Maps_MapId",
+                table: "MapEntries");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Maps_Images_ImageId",
+                table: "Maps");
+
+            migrationBuilder.DropTable(
+                name: "ImageRecordKnowledgeEntryRecord");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Events_BannerImageId",
+                table: "Events");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Events_PosterImageId",
+                table: "Events");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Dealers_ArtistImageId",
+                table: "Dealers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Dealers_ArtistThumbnailImageId",
+                table: "Dealers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Dealers_ArtPreviewImageId",
+                table: "Dealers");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "ImageId",
+                table: "Maps",
+                type: "char(36)",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "char(36)",
+                oldNullable: true)
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "MapId",
+                table: "MapEntries",
+                type: "char(36)",
+                nullable: true,
+                collation: "ascii_general_ci",
+                oldClrType: typeof(Guid),
+                oldType: "char(36)")
+                .OldAnnotation("Relational:Collation", "ascii_general_ci");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "KnowledgeEntryRecordId",
+                table: "Images",
+                type: "char(36)",
+                nullable: true,
+                collation: "ascii_general_ci");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Images_KnowledgeEntryRecordId",
+                table: "Images",
+                column: "KnowledgeEntryRecordId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Images_KnowledgeEntries_KnowledgeEntryRecordId",
+                table: "Images",
+                column: "KnowledgeEntryRecordId",
+                principalTable: "KnowledgeEntries",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MapEntries_Maps_MapId",
+                table: "MapEntries",
+                column: "MapId",
+                principalTable: "Maps",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Maps_Images_ImageId",
+                table: "Maps",
+                column: "ImageId",
+                principalTable: "Images",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/src/Eurofurence.App.Server.Services/ArtistsAlley/TableRegistrationService.cs
+++ b/src/Eurofurence.App.Server.Services/ArtistsAlley/TableRegistrationService.cs
@@ -39,7 +39,9 @@ namespace Eurofurence.App.Server.Services.ArtistsAlley
 
         public IQueryable<TableRegistrationRecord> GetRegistrations(TableRegistrationRecord.RegistrationStateEnum? state)
         {
-            var records = _appDbContext.TableRegistrations.Where(a => !state.HasValue || a.State == state.Value).AsNoTracking();
+            var records = _appDbContext.TableRegistrations
+                .Include(tr => tr.Image)
+                .Where(a => !state.HasValue || a.State == state.Value).AsNoTracking();
             return records;
         }
 

--- a/src/Eurofurence.App.Server.Services/Images/ImageService.cs
+++ b/src/Eurofurence.App.Server.Services/Images/ImageService.cs
@@ -61,8 +61,12 @@ namespace Eurofurence.App.Server.Services.Images
             var entity = await _appDbContext.Images
                 .Include(i => i.FursuitBadges)
                 .Include(i => i.TableRegistrations)
+                .Include(i => i.DealerArtPreviews)
+                .Include(i => i.DealerArtistThumbnails)
+                .Include(i => i.DealerArtists)
+                .Include(i => i.EventBanners)
+                .Include(i => i.EventPosters)
                 .Include(i => i.Maps)
-                .ThenInclude(m => m.Entries)
                 .FirstOrDefaultAsync(entity => entity.Id == id);
 
             _appDbContext.Remove(entity);
@@ -76,8 +80,12 @@ namespace Eurofurence.App.Server.Services.Images
             var images = _appDbContext.Images
                 .Include(i => i.FursuitBadges)
                 .Include(i => i.TableRegistrations)
-                .Include(i => i.Maps)
-                .ThenInclude(m => m.Entries);
+                .Include(i => i.DealerArtPreviews)
+                .Include(i => i.DealerArtistThumbnails)
+                .Include(i => i.DealerArtists)
+                .Include(i => i.EventBanners)
+                .Include(i => i.EventPosters)
+                .Include(i => i.Maps);
             var imageIds = await images.Select(image => image.Id.ToString()).ToListAsync();
             await DeleteFilesFromMinIoAsync(_minIoConfiguration.Bucket, imageIds);
             _appDbContext.Images.RemoveRange(images);
@@ -165,10 +173,7 @@ namespace Eurofurence.App.Server.Services.Images
             await _minIoClient.GetObjectAsync(new GetObjectArgs()
                 .WithBucket(_minIoConfiguration.Bucket)
                 .WithObject(id.ToString())
-                .WithCallbackStream(stream =>
-                {
-                    stream.CopyTo(ms);
-                }));
+                .WithCallbackStream(stream => { stream.CopyTo(ms); }));
 
             ms.Position = 0;
             return ms;

--- a/src/Eurofurence.App.Server.Services/Knowledge/KnowledgeEntryService.cs
+++ b/src/Eurofurence.App.Server.Services/Knowledge/KnowledgeEntryService.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Eurofurence.App.Domain.Model.Knowledge;
+using Eurofurence.App.Domain.Model.Maps;
 using Eurofurence.App.Infrastructure.EntityFramework;
 using Eurofurence.App.Server.Services.Abstractions;
 using Eurofurence.App.Server.Services.Abstractions.Knowledge;
@@ -24,6 +25,23 @@ namespace Eurofurence.App.Server.Services.Knowledge
             _appDbContext = appDbContext;
             _storageService = storageServiceFactory.CreateStorageService<KnowledgeEntryRecord>();
         }
+        public override async Task<KnowledgeEntryRecord> FindOneAsync(Guid id)
+        {
+            return await _appDbContext.KnowledgeEntries
+                .Include(m => m.Images)
+                .Include(m => m.Links)
+                .AsNoTracking()
+                .FirstOrDefaultAsync(entity => entity.Id == id);
+        }
+
+        public override IQueryable<KnowledgeEntryRecord> FindAll()
+        {
+            return _appDbContext.KnowledgeEntries
+                .Include(m => m.Images)
+                .Include(m => m.Links)
+                .AsNoTracking();
+        }
+
         public override Task ReplaceOneAsync(KnowledgeEntryRecord entity)
         {
             throw new InvalidOperationException();

--- a/src/Eurofurence.App.Server.Services/Knowledge/KnowledgeEntryService.cs
+++ b/src/Eurofurence.App.Server.Services/Knowledge/KnowledgeEntryService.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Eurofurence.App.Domain.Model.Knowledge;
-using Eurofurence.App.Domain.Model.Maps;
 using Eurofurence.App.Infrastructure.EntityFramework;
 using Eurofurence.App.Server.Services.Abstractions;
 using Eurofurence.App.Server.Services.Abstractions.Knowledge;
@@ -77,33 +76,26 @@ namespace Eurofurence.App.Server.Services.Knowledge
 
         public async Task<KnowledgeEntryRecord> ReplaceKnowledgeEntryAsync(Guid id, KnowledgeEntryRequest request)
         {
-            var images = _appDbContext.Images.Where(image => request.ImageIds.Contains(image.Id));
-
             var existingEntity = await _appDbContext.KnowledgeEntries
-                .Include(knowledgeEntryRecord => knowledgeEntryRecord.Links)
-                .AsNoTracking()
+                .Include(knowledgeEntry => knowledgeEntry.Links)
+                .Include(knowledgeEntry => knowledgeEntry.Images)
                 .FirstOrDefaultAsync(ke => ke.Id == id);
 
-            var entity = new KnowledgeEntryRecord
-            {
-                Id = id,
-                KnowledgeGroupId = request.KnowledgeGroupId,
-                Title = request.Title,
-                Text = request.Text,
-                Order = request.Order,
-                Links = request.Links,
-                IsDeleted = 0
-            };
+            existingEntity.KnowledgeGroupId = request.KnowledgeGroupId;
+            existingEntity.Title = request.Title;
+            existingEntity.Text = request.Text;
+            existingEntity.Order = request.Order;
+            existingEntity.Links = request.Links;
 
             foreach (var existingLink in existingEntity.Links)
             {
-                if (entity.Links.All(link => link.Id != existingLink.Id))
+                if (request.Links.All(link => link.Id != existingLink.Id))
                 {
                     _appDbContext.LinkFragments.Remove(existingLink);
                 }
             }
 
-            foreach (var link in entity.Links)
+            foreach (var link in request.Links)
             {
                 var linkExists = await _appDbContext.LinkFragments.AnyAsync(existingLink => existingLink.Id == link.Id);
                 if (!linkExists)
@@ -112,14 +104,13 @@ namespace Eurofurence.App.Server.Services.Knowledge
                 }
             }
 
-            entity.Images = [.. images];
+            existingEntity.Images = await _appDbContext.Images.Where(image => request.ImageIds.Contains(image.Id)).ToListAsync();
 
-            entity.Touch();
-            var result = _appDbContext.KnowledgeEntries.Update(entity);
+            existingEntity.Touch();
             await _storageService.TouchAsync();
             await _appDbContext.SaveChangesAsync();
 
-            return result.Entity;
+            return existingEntity;
         }
     }
 }

--- a/src/Eurofurence.App.Server.Services/Maps/MapService.cs
+++ b/src/Eurofurence.App.Server.Services/Maps/MapService.cs
@@ -95,7 +95,7 @@ namespace Eurofurence.App.Server.Services.Maps
 
         public async Task InsertOneEntryAsync(MapEntryRecord entity)
         {
-            var map = _appDbContext.Maps
+            var map = await _appDbContext.Maps
                 .FirstOrDefaultAsync(map => map.Id == entity.MapId);
             _appDbContext.MapEntries.Add(entity);
             await _appDbContext.SaveChangesAsync();
@@ -135,7 +135,9 @@ namespace Eurofurence.App.Server.Services.Maps
 
         public async Task DeleteOneEntryAsync(Guid id)
         {
-            var entity = await _appDbContext.MapEntries.FirstOrDefaultAsync(entity => entity.Id == id);
+            var entity = await _appDbContext.MapEntries
+                .Include(me => me.Links)
+                .FirstOrDefaultAsync(entity => entity.Id == id);
             _appDbContext.Remove(entity);
             await _storageService.TouchAsync();
             await _appDbContext.SaveChangesAsync();

--- a/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
@@ -3,6 +3,7 @@ using Eurofurence.App.Domain.Model.ArtistsAlley;
 using Eurofurence.App.Server.Services.Abstractions.ArtistsAlley;
 using Eurofurence.App.Server.Services.Abstractions.Security;
 using Eurofurence.App.Server.Web.Extensions;
+using MapsterMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -12,10 +13,12 @@ namespace Eurofurence.App.Server.Web.Controllers
     public class ArtistsAlleyController : BaseController
     {
         private readonly ITableRegistrationService _tableRegistrationService;
+        private readonly IMapper _mapper;
 
-        public ArtistsAlleyController(ITableRegistrationService tableRegistrationService)
+        public ArtistsAlleyController(ITableRegistrationService tableRegistrationService, IMapper mapper)
         {
             _tableRegistrationService = tableRegistrationService;
+            _mapper = mapper;
         }
 
         [Authorize(Roles = "Attendee")]
@@ -28,10 +31,10 @@ namespace Eurofurence.App.Server.Web.Controllers
 
         [Authorize(Roles = "Attendee")]
         [HttpGet("TableRegistration/:my-latest")]
-        public async Task<TableRegistrationRecord> GetMyLatestTableRegistrationRequestAsync()
+        public async Task<TableRegistrationResponse> GetMyLatestTableRegistrationRequestAsync()
         {
             var record = await _tableRegistrationService.GetLatestRegistrationByUidAsync(User.GetSubject());
-            return record.Transient404(HttpContext);
+            return _mapper.Map<TableRegistrationResponse>(record.Transient404(HttpContext));
         }
     }
 } 

--- a/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
@@ -29,7 +29,8 @@ namespace Eurofurence.App.Server.Web.Controllers
         [HttpGet]
         [ProducesResponseType(typeof(string), 404)]
         [ProducesResponseType(typeof(IEnumerable<TableRegistrationResponse>), 200)]
-        [HttpGet("TableRegistrations")]
+        [Authorize(Roles = "System,Developer,Admin")]
+        [HttpGet]
         public IEnumerable<TableRegistrationResponse> GetTableRegistrationsAsync()
         {
             return _mapper.Map<IEnumerable<TableRegistrationResponse>>(_tableRegistrationService.GetRegistrations(null));

--- a/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Eurofurence.App.Domain.Model.ArtistsAlley;
 using Eurofurence.App.Server.Services.Abstractions.ArtistsAlley;
 using Eurofurence.App.Server.Services.Abstractions.Security;
@@ -19,6 +20,19 @@ namespace Eurofurence.App.Server.Web.Controllers
         {
             _tableRegistrationService = tableRegistrationService;
             _mapper = mapper;
+        }
+
+        /// <summary>
+        ///     Retrieves a list of all table registrations.
+        /// </summary>
+        /// <returns>All table registrations.</returns>
+        [HttpGet]
+        [ProducesResponseType(typeof(string), 404)]
+        [ProducesResponseType(typeof(IEnumerable<TableRegistrationResponse>), 200)]
+        [HttpGet("TableRegistrations")]
+        public IEnumerable<TableRegistrationResponse> GetTableRegistrationsAsync()
+        {
+            return _mapper.Map<IEnumerable<TableRegistrationResponse>>(_tableRegistrationService.GetRegistrations(null));
         }
 
         [Authorize(Roles = "Attendee")]

--- a/src/Eurofurence.App.Server.Web/Controllers/FursuitsController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/FursuitsController.cs
@@ -6,6 +6,7 @@ using Eurofurence.App.Domain.Model.Fursuits;
 using Eurofurence.App.Server.Services.Abstractions.Fursuits;
 using Eurofurence.App.Server.Services.Abstractions.Security;
 using Eurofurence.App.Server.Web.Extensions;
+using MapsterMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -16,13 +17,16 @@ namespace Eurofurence.App.Server.Web.Controllers
     {
         private readonly IFursuitBadgeService _fursuitBadgeService;
         private readonly ICollectingGameService _collectingGameService;
+        private readonly IMapper _mapper;
 
         public FursuitsController(
             IFursuitBadgeService fursuitBadgeService,
-            ICollectingGameService collectingGameService)
+            ICollectingGameService collectingGameService,
+            IMapper mapper)
         {
             _fursuitBadgeService = fursuitBadgeService;
             _collectingGameService = collectingGameService;
+            _mapper = mapper;
         }
         /// <summary>
         ///     Upsert Fursuit Badge information
@@ -51,11 +55,11 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// </remarks>
         [Authorize(Roles = "System,Developer,FursuitBadgeSystem")]
         [HttpGet("Badges")]
-        [ProducesResponseType(typeof(FursuitBadgeRecord[]), 200)]
+        [ProducesResponseType(typeof(IEnumerable<FursuitBadgeResponse>), 200)]
         [ProducesResponseType(401)]
-        public IQueryable<FursuitBadgeRecord> GetFursuitBadgesAsync(FursuitBadgeFilter filter)
+        public IEnumerable<FursuitBadgeResponse> GetFursuitBadgesAsync(FursuitBadgeFilter filter)
         {
-            return _fursuitBadgeService.GetFursuitBadges(filter);
+            return _mapper.Map<IEnumerable<FursuitBadgeResponse>>(_fursuitBadgeService.GetFursuitBadges(filter));
         }
 
         /// <summary>
@@ -101,10 +105,10 @@ namespace Eurofurence.App.Server.Web.Controllers
 
         [Authorize(Roles = "Attendee")]
         [HttpGet("CollectingGame/FursuitParticipation")]
-        [ProducesResponseType(typeof(FursuitParticipationInfo[]), 200)]
-        public Task<IEnumerable<FursuitParticipationInfo>> GetFursuitParticipationInfoForOwnerAsync()
+        [ProducesResponseType(typeof(IEnumerable<FursuitParticipationInfoResponse>), 200)]
+        public Task<IEnumerable<FursuitParticipationInfoResponse>> GetFursuitParticipationInfoForOwnerAsync()
         {
-            return _collectingGameService.GetFursuitParticipationInfoForOwnerAsync(User.GetSubject());
+            return _mapper.Map<Task<IEnumerable<FursuitParticipationInfoResponse>>>(_collectingGameService.GetFursuitParticipationInfoForOwnerAsync(User.GetSubject()));
         }
 
         [Authorize(Roles = "Attendee")]

--- a/src/Eurofurence.App.Server.Web/Controllers/FursuitsController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/FursuitsController.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Eurofurence.App.Domain.Model.Fursuits;
 using Eurofurence.App.Server.Services.Abstractions.Fursuits;

--- a/src/Eurofurence.App.Server.Web/Controllers/ImagesController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/ImagesController.cs
@@ -11,6 +11,7 @@ using System.Text;
 using Microsoft.AspNetCore.Http;
 using System.IO;
 using MapsterMapper;
+using Microsoft.EntityFrameworkCore;
 
 namespace Eurofurence.App.Server.Web.Controllers
 {
@@ -29,13 +30,35 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <summary>
         ///     Retrieves a list of all images.
         /// </summary>
-        /// <returns>All knowledge groups.</returns>
+        /// <returns>All images.</returns>
         [HttpGet]
         [ProducesResponseType(typeof(string), 404)]
         [ProducesResponseType(typeof(IEnumerable<ImageResponse>), 200)]
         public IEnumerable<ImageResponse> GetImagesAsync()
         {
             return _mapper.Map<IEnumerable<ImageResponse>>(_imageService.FindAll());
+        }
+
+        /// <summary>
+        ///     Retrieves a list of all images with related IDs.
+        /// </summary>
+        /// <returns>All images with related IDs.</returns>
+        [HttpGet("with-relations")]
+        [ProducesResponseType(typeof(string), 404)]
+        [ProducesResponseType(typeof(IEnumerable<ImageWithRelationsResponse>), 200)]
+        public IEnumerable<ImageWithRelationsResponse> GetImagesWithRelationsAsync()
+        {
+            return _mapper.Map<IEnumerable<ImageWithRelationsResponse>>(
+                _imageService.FindAll()
+                    .Include(i => i.KnowledgeEntries)
+                    .Include(i => i.FursuitBadges)
+                    .Include(i => i.TableRegistrations)
+                    .Include(i => i.Maps)
+                    .Include(i => i.DealerArtPreviews)
+                    .Include(i => i.DealerArtistThumbnails)
+                    .Include(i => i.DealerArtists)
+                    .Include(i => i.EventBanners)
+                    .Include(i => i.EventPosters));
         }
 
         /// <summary>

--- a/src/Eurofurence.App.Server.Web/Controllers/ImagesController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/ImagesController.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Authorization;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using System.IO;
+using MapsterMapper;
 
 namespace Eurofurence.App.Server.Web.Controllers
 {
@@ -17,10 +18,12 @@ namespace Eurofurence.App.Server.Web.Controllers
     public class ImagesController : BaseController
     {
         private readonly IImageService _imageService;
+        private readonly IMapper _mapper;
 
-        public ImagesController(IImageService imageService)
+        public ImagesController(IImageService imageService, IMapper mapper)
         {
             _imageService = imageService;
+            _mapper = mapper;
         }
 
         /// <summary>
@@ -29,10 +32,10 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <returns>All knowledge groups.</returns>
         [HttpGet]
         [ProducesResponseType(typeof(string), 404)]
-        [ProducesResponseType(typeof(IEnumerable<ImageRecord>), 200)]
-        public IQueryable<ImageRecord> GetImagesAsync()
+        [ProducesResponseType(typeof(IEnumerable<ImageResponse>), 200)]
+        public IEnumerable<ImageResponse> GetImagesAsync()
         {
-            return _imageService.FindAll();
+            return _mapper.Map<IEnumerable<ImageResponse>>(_imageService.FindAll());
         }
 
         /// <summary>
@@ -41,10 +44,10 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <param name="id">id of the requested entity</param>
         [HttpGet("{id}")]
         [ProducesResponseType(typeof(string), 404)]
-        [ProducesResponseType(typeof(ImageRecord), 200)]
-        public async Task<ImageRecord> GetImageAsync([FromRoute] Guid id)
+        [ProducesResponseType(typeof(ImageResponse), 200)]
+        public async Task<ImageResponse> GetImageAsync([FromRoute] Guid id)
         {
-            return (await _imageService.FindOneAsync(id)).Transient404(HttpContext);
+            return _mapper.Map<ImageResponse>(await _imageService.FindOneAsync(id).Transient404(HttpContext));
         }
 
         /// <summary>
@@ -102,7 +105,7 @@ namespace Eurofurence.App.Server.Web.Controllers
             {
                 await file.CopyToAsync(ms);
                 var result = await _imageService.ReplaceImageAsync(record.Id, file.FileName, ms);
-                return Ok(result);
+                return Ok(_mapper.Map<ImageResponse>(result));
             }
         }
 
@@ -119,7 +122,7 @@ namespace Eurofurence.App.Server.Web.Controllers
             {
                 await file.CopyToAsync(ms);
                 var result = await _imageService.InsertImageAsync(file.FileName, ms);
-                return Ok(result);
+                return Ok(_mapper.Map<ImageResponse>(result));
             }
         }
 

--- a/src/Eurofurence.App.Server.Web/Controllers/KnowledgeEntriesController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/KnowledgeEntriesController.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Eurofurence.App.Domain.Model.Knowledge;
 using Eurofurence.App.Server.Services.Abstractions.Knowledge;
 using Eurofurence.App.Server.Web.Extensions;
+using MapsterMapper;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
@@ -15,10 +16,12 @@ namespace Eurofurence.App.Server.Web.Controllers
     public class KnowledgeEntriesController : BaseController
     {
         private readonly IKnowledgeEntryService _knowledgeEntryService;
+        private readonly IMapper _mapper;
 
-        public KnowledgeEntriesController(IKnowledgeEntryService knowledgeEntryService)
+        public KnowledgeEntriesController(IKnowledgeEntryService knowledgeEntryService, IMapper mapper)
         {
             _knowledgeEntryService = knowledgeEntryService;
+            _mapper = mapper;
         }
 
         /// <summary>
@@ -27,12 +30,12 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <returns>All knowledge Entries.</returns>
         [HttpGet]
         [ProducesResponseType(typeof(string), 404)]
-        [ProducesResponseType(typeof(IEnumerable<KnowledgeEntryRecord>), 200)]
-        public IQueryable<KnowledgeEntryRecord> GetKnowledgeEntriesAsync()
+        [ProducesResponseType(typeof(IEnumerable<KnowledgeEntryResponse>), 200)]
+        public IEnumerable<KnowledgeEntryResponse> GetKnowledgeEntriesAsync()
         {
-            return _knowledgeEntryService.FindAll()
+            return _mapper.Map<IEnumerable<KnowledgeEntryResponse>>(_knowledgeEntryService.FindAll()
                 .Include(ke => ke.Images)
-                .Include(ke => ke.Links);
+                .Include(ke => ke.Links));
         }
 
         /// <summary>
@@ -41,13 +44,13 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <param name="id">id of the requested entity</param>
         [HttpGet("{id}")]
         [ProducesResponseType(typeof(string), 404)]
-        [ProducesResponseType(typeof(KnowledgeEntryRecord), 200)]
-        public async Task<KnowledgeEntryRecord> GetKnowledgeEntryAsync([FromRoute] Guid id)
+        [ProducesResponseType(typeof(KnowledgeEntryResponse), 200)]
+        public async Task<KnowledgeEntryResponse> GetKnowledgeEntryAsync([FromRoute] Guid id)
         {
-            return (await _knowledgeEntryService.FindAll()
+            return _mapper.Map<KnowledgeEntryResponse>(await _knowledgeEntryService.FindAll()
                 .Include(ke => ke.Images)
                 .Include(ke => ke.Links)
-                .FirstOrDefaultAsync(entity => entity.Id == id)).Transient404(HttpContext);
+                .FirstOrDefaultAsync(entity => entity.Id == id).Transient404(HttpContext));
         }
 
 

--- a/src/Eurofurence.App.Server.Web/Controllers/MapsController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/MapsController.cs
@@ -171,7 +171,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     Create a new map entry in a specific map
         /// </summary>
         /// <remarks>If you can generate guids client-side, you can also use the PUT variant for both create and update.</remarks>
-        /// <param name="request"></param>
+        /// <param name="request">Do not specify the "Id" property. It will be auto-assigned and returned in the response.</param>
         /// <param name="id">"Id" of the map</param>
         /// <returns>The id of the new map entry (guid)</returns>
         /// <response code="400">
@@ -195,13 +195,14 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     Create or Update an existing map entry in a specific map
         /// </summary>
         /// <remarks>
-        ///     This both works for updating an existing entry and creating a new entry.
+        ///     The id property of the model (request body) is optional, but if provided, it must match the {entryId} part of the uri.
         /// </remarks>
-        /// <param name="request"></param>
+        /// <param name="request">"Id" property must match the {EntryId} part of the uri</param>
         /// <param name="id">"Id" of the map.</param>
         /// <param name="entryId">"Id" of the entry that gets inserted.</param>
         /// <response code="400">
         ///     * Unable to parse `record`, `id` or `entryId`
+        ///     * `record.Id` does not match `entryId` from uri.
         ///     * No map found with for the specified id.
         /// </response>
         [HttpPut("{id}/Entries/{entryId}")]
@@ -213,10 +214,11 @@ namespace Eurofurence.App.Server.Web.Controllers
             if (request == null) return BadRequest("Error parsing Record");
             if (id == Guid.Empty) return BadRequest("Error parsing Id");
             if (entryId == Guid.Empty) return BadRequest("Error parsing EntryId");
+            if (request.Id != Guid.Empty && request.Id != entryId) return BadRequest("EntityId must match Record.Id");
 
             var map = await _mapService.FindOneAsync(id);
             if (map == null) return BadRequest("No map with this id");
-            
+
             foreach (var link in request.Links)
             {
                 var linkValidation = await _linkFragmentValidator.ValidateAsync(link);

--- a/src/Eurofurence.App.Server.Web/Controllers/WebPreviewController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/WebPreviewController.cs
@@ -116,9 +116,7 @@ namespace Eurofurence.App.Server.Web.Controllers
                                         && link.Target.Equals(dealer.Id.ToString(), StringComparison.CurrentCultureIgnoreCase))))
                 {
                     entry.Map = map;
-                    entry.Map.Image = await _imageService.FindOneAsync(entry.Map.ImageId);
                     mapEntries.Add(entry);
-
                 }
             }
 

--- a/src/Eurofurence.App.Server.Web/Controllers/WebPreviewController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/WebPreviewController.cs
@@ -122,14 +122,7 @@ namespace Eurofurence.App.Server.Web.Controllers
                 }
             }
 
-
             ViewData["MapEntries"] = mapEntries;
-
-            
-            
-
-            
-
 
             PopulateViewData();
 
@@ -140,16 +133,14 @@ namespace Eurofurence.App.Server.Web.Controllers
                 .WithDescription(dealer.ShortDescription)
                 .WithImage(previewImageId.HasValue ? $"{_conventionSettings.ApiBaseUrl}/Images/{previewImageId}/Content" : string.Empty);
 
-            
-
             return View("DealerPreview", dealer);
         }
 
         [HttpGet("KnowledgeGroups")]
         public async Task<ActionResult> GetKnowledgeGroups()
         {
-            var knowledgeGroups = _knowledgeGroupService.FindAll();
-            var knowledgeEntries = _knowledgeEntryService.FindAll();
+            var knowledgeGroups = await _knowledgeGroupService.FindAll().ToListAsync();
+            var knowledgeEntries = await _knowledgeEntryService.FindAll().ToListAsync();
 
             PopulateViewData();
 
@@ -158,7 +149,7 @@ namespace Eurofurence.App.Server.Web.Controllers
                 .WithDescription("Helpful information across all areas & departments");
 
             ViewData["knowledgeEntries"] = knowledgeEntries;
-            return View("KnowledgeGroupsPreview", await knowledgeGroups.ToListAsync());
+            return View("KnowledgeGroupsPreview", knowledgeGroups);
         }
 
         [HttpGet("KnowledgeEntries/{id}")]

--- a/src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj
+++ b/src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="FluentScheduler" Version="5.5.1" />
     <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0" />
+    <PackageReference Include="Mapster.DependencyInjection" Version="1.0.1" />
     <PackageReference Include="Markdig" Version="0.37.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Eurofurence.App.Server.Web/Mapper/ImageWithRelationsResponseRegister.cs
+++ b/src/Eurofurence.App.Server.Web/Mapper/ImageWithRelationsResponseRegister.cs
@@ -1,0 +1,27 @@
+﻿using System.Linq;
+using Mapster;
+using Eurofurence.App.Domain.Model.Images;
+
+namespace Eurofurence.App.Server.Web.Mapper
+{
+    /// <summary>
+    /// Mapping register for mapping IDs of image relations to the response type
+    /// </summary>
+    public class ImageWithRelationsResponseRegister : IRegister
+    {
+        public void Register(TypeAdapterConfig config)
+        {
+            config
+                .NewConfig<ImageRecord, ImageWithRelationsResponse>()
+                .Map(dest => dest.KnowledgeEntryIds, src => src.KnowledgeEntries.Select(ke => ke.Id))
+                .Map(dest => dest.FursuitBadgeIds, src => src.FursuitBadges.Select(fb => fb.Id))
+                .Map(dest => dest.TableRegistrationIds, src => src.TableRegistrations.Select(tr => tr.Id))
+                .Map(dest => dest.MapIds, src => src.Maps.Select(m => m.Id))
+                .Map(dest => dest.EventBannerIds, src => src.EventBanners.Select(eb => eb.Id))
+                .Map(dest => dest.EventPosterIds, src => src.EventPosters.Select(ep => ep.Id))
+                .Map(dest => dest.DealerArtistIds, src => src.DealerArtists.Select(da => da.Id))
+                .Map(dest => dest.DealerArtistThumbnailIds, src => src.DealerArtistThumbnails.Select(dat => dat.Id))
+                .Map(dest => dest.DealerArtPreviewIds, src => src.DealerArtPreviews.Select(dap => dap.Id));
+        }
+    }
+}

--- a/src/Eurofurence.App.Server.Web/Startup.cs
+++ b/src/Eurofurence.App.Server.Web/Startup.cs
@@ -18,7 +18,6 @@ using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Context;
 using Serilog.Events;
-using Serilog.Formatting.Json;
 using Swashbuckle.AspNetCore.SwaggerUI;
 using System;
 using System.Text.Json;
@@ -27,11 +26,11 @@ using Eurofurence.App.Infrastructure.EntityFramework;
 using Eurofurence.App.Server.Web.Identity;
 using IdentityModel.AspNetCore.OAuth2Introspection;
 using Microsoft.OpenApi.Models;
-using Eurofurence.App.Server.Services.Abstractions.MinIO;
 using Microsoft.AspNetCore.Authentication;
-using Minio;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 using Eurofurence.App.Server.Services.Abstractions.QrCode;
+using Mapster;
+using MapsterMapper;
 
 namespace Eurofurence.App.Server.Web
 {
@@ -193,6 +192,13 @@ namespace Eurofurence.App.Server.Web
                     serverVersion,
                     mySqlOptions => mySqlOptions.UseMicrosoftJson());
             });
+
+            // Add Mapster for mapping DTOs
+            var typeAdapterConfig = TypeAdapterConfig.GlobalSettings;
+            typeAdapterConfig.Default.PreserveReference(true);
+            typeAdapterConfig.Scan(typeof(Startup).Assembly);
+            services.AddSingleton(typeAdapterConfig);
+            services.AddScoped<IMapper, ServiceMapper>();
 
             builder.Build();
 

--- a/src/Eurofurence.App.Server.Web/Views/WebPreview/DealerPreview.cshtml
+++ b/src/Eurofurence.App.Server.Web/Views/WebPreview/DealerPreview.cshtml
@@ -48,20 +48,20 @@
 <section class="summary">
     @if (!string.IsNullOrEmpty(Model.TwitterHandle))
     {
-        <a href="https://twitter.com/@Model.TwitterHandle" title="Twitter: @@Model.TwitterHandle" class="button button-primary"><i class="fa-twitter"></i> @Model.TwitterHandle</a>
+        <a href="https://twitter.com/@Model.TwitterHandle" title="Twitter: @@Model.TwitterHandle" class="button button-primary"><i class="fa-brands fa-twitter"></i> @Model.TwitterHandle</a>
     }
     @if (!string.IsNullOrEmpty(Model.TelegramHandle))
     {
-        <a href="https://t.me/@Model.TelegramHandle" title="Telegram: @@@Model.TelegramHandle" class="button button-primary"><i class="fa-telegram"></i> @Model.TelegramHandle</a>
+        <a href="https://t.me/@Model.TelegramHandle" title="Telegram: @@@Model.TelegramHandle" class="button button-primary"><i class="fa-brands fa-telegram"></i> @Model.TelegramHandle</a>
     }
     <!-- TODO: Add Discord, Mastodon etc. -->
     @if (days.Length > 0)
     {
-        <div class="infobox"><label><i class="fa-calendar"></i> Available:</label> @string.Join(", ", days)</div>
+        <div class="infobox"><label><i class="fa fa-calendar"></i> Available:</label> @string.Join(", ", days)</div>
     }
     @if (Model.IsAfterDark)
     {
-        <div class="infobox"><label><i class="fa-moon-o"></i> After Dark</label></div>
+        <div class="infobox"><label><i class="fa fa-moon"></i> After Dark</label></div>
     }
 </section>
 
@@ -86,14 +86,12 @@
     @if (Model.ArtPreviewImageId != null)
     {
         <div class="one-half column">
-            <img src="@apiBaseUrl/Images/@Model.ArtPreviewImageId.ToString()/Content" title="@Model.ArtPreviewCaption" 
-                 style="max-width: 100%;"
-                 />
+            <img src="@apiBaseUrl/Images/@Model.ArtPreviewImageId.ToString()/Content" title="@Model.ArtPreviewCaption" style="max-width: 100%;" />
 
             @if (Model.ArtPreviewCaption != null)
             {
                 <br />
-                <p><small>@Model.ArtPreviewCaption></small></p>
+                <p><small>@Model.ArtPreviewCaption</small></p>
             }
         </div>
     }

--- a/src/Eurofurence.App.Tools.CliToolBox/Commands/MapCommand.cs
+++ b/src/Eurofurence.App.Tools.CliToolBox/Commands/MapCommand.cs
@@ -179,7 +179,10 @@ namespace Eurofurence.App.Tools.CliToolBox.Commands
                 command.Out.WriteLine($"Deleting map {map.Id} (Description={map.Description}, IsBrowseable={map.IsBrowseable})");
 
                 _mapService.DeleteOneAsync(map.Id).Wait();
-                _imageService.DeleteOneAsync(map.ImageId).Wait();
+                if (map.ImageId != null)
+                {
+                    _imageService.DeleteOneAsync((Guid)map.ImageId).Wait();
+                }
 
                 return 0;
             });


### PR DESCRIPTION
I added request and response models for endpoints where it was needed to maintain a simpler API schema as it was before.
This includes knowledge base, images, maps and more.

Also the commits from #128 were included here.