### PR TITLE
108 add minio url to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN dotnet restore \
 	&& dotnet publish src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj --output "/app/artifacts" --configuration Release
 RUN dotnet tool install --global dotnet-ef \
 	&& export PATH="$PATH:/root/.dotnet/tools" \
-	&& dotnet ef migrations bundle -o "/app/artifacts/db-migration-bundle" -p src/Eurofurence.App.Server.Web
+	&& dotnet ef migrations bundle -o "/app/artifacts/db-migration-bundle" -p src/Eurofurence.App.Infrastructure.EntityFramework
 ENTRYPOINT dotnet artifacts/Eurofurence.App.Server.Web.dll http://*:30001
 EXPOSE 30001
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,8 @@ services:
       MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
     volumes:
       - db:/var/lib/mysql
+    ports:
+      - '33306:3306'
     healthcheck:
       test: mariadb-admin ping -h 127.0.0.1 -u root
       start_period: 5s

--- a/src/Eurofurence.App.Backoffice/Components/ImageDialog.razor
+++ b/src/Eurofurence.App.Backoffice/Components/ImageDialog.razor
@@ -11,8 +11,8 @@
                 <MudContainer Style="height: 600px" Class="overflow-scroll pr-4">
                     <MudGrid>
                         <MudItem xs="6">
-                            <MudImage ObjectFit="ObjectFit.Contain" Height="500" Width="500" Class="ml-2" Src="@_imageSource">
-                                @if (string.IsNullOrEmpty(_imageSource))
+                            <MudImage ObjectFit="ObjectFit.Contain" Height="500" Width="500" Class="ml-2" Src="@Record.Url">
+                                @if (string.IsNullOrEmpty(@Record.Url))
                                 {
                                     <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
                                 }
@@ -57,9 +57,7 @@
 
     private bool Update { get; set; }
 
-    private string _imageSource = string.Empty;
-
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
         if (Record == null)
         {
@@ -68,25 +66,9 @@
         else
         {
             Update = true;
-            await LoadImageSourceAsync();
         }
     }
-
-    private async Task LoadImageSourceAsync()
-    {
-        if (Record == null)
-        {
-            return;
-        }
-
-        var imageContent = await ImageService.GetImageContentAsync(Record.Id);
-        if (!string.IsNullOrEmpty(imageContent))
-        {
-            _imageSource = $"data:image/jpeg;base64,{imageContent}";
-            StateHasChanged();
-        }
-    }
-
+    
     private async Task UploadImage(IBrowserFile? file)
     {
         if (file == null || Record == null)
@@ -94,9 +76,10 @@
             return;
         }
 
+        ImageResponse? image;
         if (Update)
         {
-            var image = await ImageService.PutImageAsync(Record.Id, file);
+            image = await ImageService.PutImageAsync(Record.Id, file);
             if (image != null)
             {
                 Snackbar.Add("Image updated.", Severity.Success);
@@ -108,7 +91,7 @@
         }
         else
         {
-            var image = await ImageService.PostImageAsync(file);
+            image = await ImageService.PostImageAsync(file);
             if (image != null)
             {
                 Snackbar.Add("Image added.", Severity.Success);
@@ -119,7 +102,18 @@
             }
         }
 
-        await LoadImageSourceAsync();
+        if (image != null)
+        {
+            Record.Id = image.Id;
+            Record.InternalReference = image.InternalReference;
+            Record.SizeInBytes = image.SizeInBytes;
+            Record.MimeType = image.MimeType;
+            Record.Width = image.Width;
+            Record.Height = image.Height;
+            Record.Url = image.Url + "?" + Guid.NewGuid();
+        }
+
+        StateHasChanged();
     }
 
     private void Close()

--- a/src/Eurofurence.App.Backoffice/Components/KnowledgeEntryDialog.razor
+++ b/src/Eurofurence.App.Backoffice/Components/KnowledgeEntryDialog.razor
@@ -61,13 +61,18 @@
                         {
                             <MudDataGrid Items="@Record.Images" Filterable="false" SortMode="@SortMode.None" Groupable="false">
                                 <Columns>
-                                    <PropertyColumn Title="ID" Property="image => image.Id" />
-                                    <PropertyColumn Title="Name" Property="image => image.InternalReference" />
-                                    <PropertyColumn Title="Size (Bytes)" Property="image => image.SizeInBytes" />
-                                    <PropertyColumn Title="Last Changed" Property="image => image.LastChangeDateTimeUtc" />
                                     <TemplateColumn CellClass="d-flex justify-end">
                                         <CellTemplate>
-                                            <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick="@(() => DeleteImage(@context.Item.Id))" />
+                                            <MudImage Height="100" ObjectFit="ObjectFit.Contain" Src="@context.Item.Url" />
+                                        </CellTemplate>
+                                    </TemplateColumn>
+                                    <PropertyColumn Title="ID" Property="image => image.Id"/>
+                                    <PropertyColumn Title="Name" Property="image => image.InternalReference"/>
+                                    <PropertyColumn Title="Size (Bytes)" Property="image => image.SizeInBytes"/>
+                                    <PropertyColumn Title="Last Changed" Property="image => image.LastChangeDateTimeUtc"/>
+                                    <TemplateColumn>
+                                        <CellTemplate>
+                                            <MudIconButton Icon="@Icons.Material.Filled.Delete" OnClick="@(() => DeleteImage(@context.Item.Id))"/>
                                         </CellTemplate>
                                     </TemplateColumn>
                                 </Columns>
@@ -152,6 +157,7 @@
             Record?.Images.Add(new ImageRecord()
             {
                 Id = image.Id,
+                Url = image.Url,
                 InternalReference = image.InternalReference,
                 MimeType = image.MimeType,
                 SizeInBytes = image.SizeInBytes,

--- a/src/Eurofurence.App.Backoffice/Pages/Images.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/Images.razor
@@ -19,9 +19,11 @@
     <Columns>
         <TemplateColumn Title="Preview" CellClass="d-flex justify-center">
             <CellTemplate>
-                @if (!string.IsNullOrEmpty(@_imageContents.FirstOrDefault(kvp => kvp.Key == @context.Item.Id).Value))
+                @if (!string.IsNullOrEmpty(@context.Item.Url))
                 {
-                    <MudImage Class="ml-2" Width="100" Src="@_imageContents.FirstOrDefault(kvp => kvp.Key == @context.Item.Id).Value"/>
+                    <MudLink Href="@context.Item.Url">
+                        <MudImage Class="ml-2" Width="100" Height="100" ObjectFit="ObjectFit.Contain" Src="@context.Item.Url" />
+                    </MudLink>
                 }
                 else
                 {
@@ -98,7 +100,6 @@
 @code {
     private string? _imageSearch;
     private List<ImageWithRelationsResponse> _images = new();
-    private List<KeyValuePair<Guid, string>> _imageContents = [];
     private MudDataGrid<ImageWithRelationsResponse>? _dataGrid;
 
     private async Task<GridData<ImageWithRelationsResponse?>> GetImages(GridState<ImageWithRelationsResponse?> gridState)
@@ -112,26 +113,15 @@
         var filteredItems = FilterImages(_images, _imageSearch).ToList();
         result.Items = filteredItems.Skip(gridState.Page * gridState.PageSize).Take(gridState.PageSize);
         result.TotalItems = filteredItems.Count;
-        _ = Task.Run(() => LoadImageSourcesAsync(result.Items.Select(item => item!.Id)));
         return result;
     }
 
     private async Task LoadImagesAsync()
     {
         _images = (await ImageService.GetImagesWithRelationsAsync()).ToList();
-    }
-
-    private async Task LoadImageSourcesAsync(IEnumerable<Guid> imageIds)
-    {
-        _imageContents = [];
-        foreach (var imageId in imageIds)
+        foreach (var image in _images)
         {
-            var imageContent = await ImageService.GetImageContentAsync(imageId);
-            if (!string.IsNullOrEmpty(imageContent))
-            {
-                _imageContents.Add(new KeyValuePair<Guid, string>(imageId, $"data:image/jpeg;base64,{imageContent}"));
-                StateHasChanged();
-            }
+            image.Url += "?" + Guid.NewGuid();
         }
     }
 
@@ -155,8 +145,12 @@
         var parameters = new DialogParameters<ImageDialog> { { x => x.Record, null } };
         var options = new DialogOptions() { MaxWidth = MaxWidth.Large, FullWidth = true };
 
-        await DialogService.ShowAsync<ImageDialog>("New image", parameters, options);
+        var dialog = await DialogService.ShowAsync<ImageDialog>("New image", parameters, options);
 
+        await dialog.Result;
+
+        await LoadImagesAsync();
+        StateHasChanged();
         _dataGrid?.ReloadServerData();
     }
 
@@ -165,8 +159,11 @@
         var parameters = new DialogParameters<ImageDialog> { { x => x.Record, record } };
         var options = new DialogOptions { MaxWidth = MaxWidth.Large, FullWidth = true };
 
-        await DialogService.ShowAsync<ImageDialog>("Update image", parameters, options);
+        var dialog = await DialogService.ShowAsync<ImageDialog>("Update image", parameters, options);
+        await dialog.Result;
 
+        await LoadImagesAsync();
+        StateHasChanged();
         _dataGrid?.ReloadServerData();
     }
 

--- a/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
@@ -100,18 +100,10 @@
                     <MudCardContent>
                         <MudText Class="mb-4">@((MarkupString)Markdown.ToHtml(knowledgeEntry.Text))</MudText>
 
-                        @if (_imageContents.Any(kvp => kvp.Key == knowledgeEntry.Id))
+                        @foreach (var image in knowledgeEntry.Images)
                         {
-                            @foreach (var image in _imageContents.FirstOrDefault(kvp => kvp.Key == knowledgeEntry.Id).Value)
-                            {
-                                <MudImage Class="ml-2" Height="100" Src="@image"/>
-                            }
+                            <MudImage Class="ml-2" Height="100" ObjectFit="ObjectFit.Contain" Src="@image.Url" />
                         }
-                        else if (knowledgeEntry.Images.Count > 0)
-                        {
-                            <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
-                        }
-
                     </MudCardContent>
                     <MudCardActions>
                         @foreach (var link in knowledgeEntry.Links)
@@ -131,13 +123,11 @@
     private KnowledgeGroupRecord? _selectedGroup;
     private List<KnowledgeGroupRecord> _knowledgeGroups = new List<KnowledgeGroupRecord>();
     private List<KnowledgeEntryRecord> _knowledgeEntries = new List<KnowledgeEntryRecord>();
-    private List<KeyValuePair<Guid, List<string>>> _imageContents = [];
 
     protected override async Task OnInitializedAsync()
     {
         await LoadKnowledgeEntries();
         await LoadKnowledgeGroups();
-        await LoadImageSourcesAsync();
     }
 
     private async Task LoadKnowledgeEntries()
@@ -146,7 +136,6 @@
         _knowledgeEntries = [];
 
         var responses = (await KnowledgeService.GetKnowledgeEntriesAsync()).OrderBy(ke => ke.Order);
-        var imageResponses = await ImageService.GetImagesAsync();
         foreach (var response in responses)
         {
             var record = new KnowledgeEntryRecord()
@@ -160,20 +149,25 @@
                 IsDeleted = response.IsDeleted,
                 Links = response.Links
             };
-            foreach (var image in response.Images)
+            foreach (var imageId in response.ImageIds)
             {
-                record.Images.Add(new ImageRecord()
+                var image = await ImageService.GetImageAsync(imageId);
+                if (image != null)
                 {
-                    Id = image.Id,
-                    Height = image.Height,
-                    Width = image.Width,
-                    ContentHashSha1 = image.ContentHashSha1,
-                    InternalReference = image.InternalReference,
-                    MimeType = image.MimeType,
-                    SizeInBytes = image.SizeInBytes,
-                    LastChangeDateTimeUtc = image.LastChangeDateTimeUtc,
-                    IsDeleted = image.IsDeleted
-                });
+                    record.Images.Add(new ImageRecord()
+                    {
+                        Id = image.Id,
+                        Url = image.Url,
+                        Height = image.Height,
+                        Width = image.Width,
+                        ContentHashSha1 = image.ContentHashSha1,
+                        InternalReference = image.InternalReference,
+                        MimeType = image.MimeType,
+                        SizeInBytes = image.SizeInBytes,
+                        LastChangeDateTimeUtc = image.LastChangeDateTimeUtc,
+                        IsDeleted = image.IsDeleted
+                    });
+                }
             }
 
             _knowledgeEntries.Add(record);
@@ -186,31 +180,6 @@
     {
         Loading = true;
         _knowledgeGroups = (await KnowledgeService.GetKnowledgeGroupsAsync()).OrderBy(kg => kg.Order).ToList();
-        Loading = false;
-    }
-
-    private async Task LoadImageSourcesAsync()
-    {
-        Loading = true;
-        _imageContents = [];
-
-        foreach (var knowledgeEntry in _knowledgeEntries)
-        {
-            StateHasChanged();
-            var keyValuePair = new KeyValuePair<Guid, List<string>>(knowledgeEntry.Id, new List<string>());
-
-            foreach (var image in knowledgeEntry.Images)
-            {
-                var imageContent = await ImageService.GetImageContentAsync(image.Id);
-                if (!string.IsNullOrEmpty(imageContent))
-                {
-                    keyValuePair.Value.Add($"data:image/jpeg;base64,{imageContent}");
-                }
-            }
-
-            _imageContents.Add(keyValuePair);
-        }
-
         Loading = false;
     }
 
@@ -238,11 +207,10 @@
         var dialog = await DialogService.ShowAsync<KnowledgeEntryDialog>("New knowledge base entry", parameters, options);
         var result = await dialog.Result;
 
-        if (!result.Canceled)
+        if (result is { Canceled: false })
         {
             Loading = true;
             await LoadKnowledgeEntries();
-            await LoadImageSourcesAsync();
         }
     }
 
@@ -252,14 +220,10 @@
         var options = new DialogOptions() { MaxWidth = MaxWidth.Large, FullWidth = true };
 
         var dialog = await DialogService.ShowAsync<KnowledgeEntryDialog>("Update knowledge base entry", parameters, options);
-        var result = await dialog.Result;
+        await dialog.Result;
 
-        if (!result.Canceled)
-        {
-            Loading = true;
-            await LoadKnowledgeEntries();
-            await LoadImageSourcesAsync();
-        }
+        Loading = true;
+        await LoadKnowledgeEntries();
     }
 
     private async Task DeleteKnowledgeEntry(Guid id)
@@ -291,7 +255,7 @@
         var dialog = await DialogService.ShowAsync<KnowledgeGroupDialog>("Update knowledge base group", parameters, options);
         var result = await dialog.Result;
 
-        if (!result.Canceled)
+        if (result is { Canceled: false })
         {
             Loading = true;
             await LoadKnowledgeGroups();

--- a/src/Eurofurence.App.Backoffice/Services/IImageService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/IImageService.cs
@@ -5,9 +5,9 @@ namespace Eurofurence.App.Backoffice.Services
 {
     public interface IImageService
     {
+        public Task<ImageResponse?> GetImageAsync(Guid id);
         public Task<ImageResponse[]> GetImagesAsync();
         public Task<ImageWithRelationsResponse[]> GetImagesWithRelationsAsync();
-        public Task<string> GetImageContentAsync(Guid id);
         public Task<ImageResponse?> PutImageAsync(Guid id, IBrowserFile file);
         public Task<ImageResponse?> PostImageAsync(IBrowserFile file);
         public Task<bool> DeleteImageAsync(Guid id);

--- a/src/Eurofurence.App.Backoffice/Services/ImageService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/ImageService.cs
@@ -9,6 +9,11 @@ namespace Eurofurence.App.Backoffice.Services
 {
     public class ImageService(HttpClient http) : IImageService
     {
+        public async Task<ImageResponse?> GetImageAsync(Guid id)
+        {
+            return (await http.GetFromJsonAsync<ImageResponse>($"images/{id}"));
+        }
+
         public async Task<ImageResponse[]> GetImagesAsync()
         {
             return (await http.GetFromJsonAsync<ImageResponse[]>("images"))?.Where(ke => ke.IsDeleted != 1).ToArray() ?? [];
@@ -17,18 +22,6 @@ namespace Eurofurence.App.Backoffice.Services
         public async Task<ImageWithRelationsResponse[]> GetImagesWithRelationsAsync()
         {
             return (await http.GetFromJsonAsync<ImageWithRelationsResponse[]>("images/with-relations"))?.Where(ke => ke.IsDeleted != 1).ToArray() ?? [];
-        }
-
-        public async Task<string> GetImageContentAsync(Guid id)
-        {
-            try
-            {
-                return Convert.ToBase64String(await http.GetByteArrayAsync($"images/{id}/Content"));
-            }
-            catch
-            {
-                return string.Empty;
-            }
         }
 
         public async Task<ImageResponse?> PutImageAsync(Guid id, IBrowserFile file)

--- a/src/Eurofurence.App.Domain.Model/Images/ImageRecord.cs
+++ b/src/Eurofurence.App.Domain.Model/Images/ImageRecord.cs
@@ -39,6 +39,14 @@ namespace Eurofurence.App.Domain.Model.Images
         [DataMember]
         public string ContentHashSha1 { get; set; }
 
+        [Required]
+        [DataMember]
+        public string Url { get; set; }
+
+        [Required]
+        [JsonIgnore]
+        public string InternalFileName { get; set; }
+
         [IgnoreDataMember]
         [JsonIgnore]
         public virtual List<AnnouncementRecord> Announcements { get; set; } = new();

--- a/src/Eurofurence.App.Domain.Model/Images/ImageResponse.cs
+++ b/src/Eurofurence.App.Domain.Model/Images/ImageResponse.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Eurofurence.App.Domain.Model.Images
 {
@@ -22,5 +23,11 @@ namespace Eurofurence.App.Domain.Model.Images
 
         [DataMember]
         public string ContentHashSha1 { get; set; }
+
+        [DataMember]
+        public string Url { get; set; }
+
+        [JsonIgnore]
+        public string InternalFileName { get; set; }
     }
 }

--- a/src/Eurofurence.App.Domain.Model/Knowledge/KnowledgeEntryResponse.cs
+++ b/src/Eurofurence.App.Domain.Model/Knowledge/KnowledgeEntryResponse.cs
@@ -25,6 +25,6 @@ namespace Eurofurence.App.Domain.Model.Knowledge
         public virtual List<LinkFragment> Links { get; set; } = new();
 
         [DataMember]
-        public virtual List<ImageResponse> Images { get; set; } = new();
+        public virtual List<Guid> ImageIds { get; set; } = new();
     }
 }

--- a/src/Eurofurence.App.Infrastructure.EntityFramework/AppDbContext.cs
+++ b/src/Eurofurence.App.Infrastructure.EntityFramework/AppDbContext.cs
@@ -1,4 +1,5 @@
-﻿using Eurofurence.App.Domain.Model.Announcements;
+﻿using System;
+using Eurofurence.App.Domain.Model.Announcements;
 using Eurofurence.App.Domain.Model.ArtistsAlley;
 using Eurofurence.App.Domain.Model.ArtShow;
 using Eurofurence.App.Domain.Model.CollectionGame;
@@ -22,6 +23,7 @@ namespace Eurofurence.App.Infrastructure.EntityFramework
 {
     public class AppDbContext : DbContext
     {
+        public AppDbContext() { }
         public AppDbContext(DbContextOptions<AppDbContext> options)
             : base(options)
         {
@@ -59,6 +61,26 @@ namespace Eurofurence.App.Infrastructure.EntityFramework
         public virtual DbSet<RoleRecord> Roles { get; set; }
         public virtual DbSet<TopicRecord> Topics { get; set; }
         public virtual DbSet<LinkFragment> LinkFragments { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+                var connectionString = "Server=db; Port=3306; Database=ef_backend; user=root; SslMode=Preferred;";
+
+                var serverVersionString = Environment.GetEnvironmentVariable("MYSQL_VERSION");
+                ServerVersion serverVersion;
+                if (string.IsNullOrEmpty(serverVersionString) || !ServerVersion.TryParse(serverVersionString, out serverVersion))
+                {
+                    serverVersion = ServerVersion.AutoDetect(connectionString);
+                }
+                
+                optionsBuilder.UseMySql(
+                    connectionString,
+                    serverVersion,
+                    mySqlOptions => mySqlOptions.UseMicrosoftJson());
+            }
+        }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240803204301_AddImageUrl.Designer.cs
+++ b/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240803204301_AddImageUrl.Designer.cs
@@ -4,6 +4,7 @@ using Eurofurence.App.Infrastructure.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Eurofurence.App.Infrastructure.EntityFramework.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240803204301_AddImageUrl")]
+    partial class AddImageUrl
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240803204301_AddImageUrl.cs
+++ b/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240803204301_AddImageUrl.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eurofurence.App.Infrastructure.EntityFramework.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImageUrl : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "InternalFileName",
+                table: "Images",
+                type: "longtext",
+                nullable: false)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Url",
+                table: "Images",
+                type: "longtext",
+                nullable: false)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InternalFileName",
+                table: "Images");
+
+            migrationBuilder.DropColumn(
+                name: "Url",
+                table: "Images");
+        }
+    }
+}

--- a/src/Eurofurence.App.Server.Services/Abstractions/MinIO/MinIOConfiguration.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/MinIO/MinIOConfiguration.cs
@@ -5,6 +5,7 @@ namespace Eurofurence.App.Server.Services.Abstractions.MinIO
     public class MinIoConfiguration
     {
         public string Endpoint { get; set; }
+        public string BaseUrl { get; set; }
         public string Region { get; set; }
         public string AccessKey { get; set; }
         public string SecretKey { get; set; }
@@ -15,6 +16,7 @@ namespace Eurofurence.App.Server.Services.Abstractions.MinIO
             => new()
             {
                 Endpoint = configuration["minIo:endpoint"],
+                BaseUrl = configuration["minIo:baseUrl"] ?? configuration["minIo:endpoint"],
                 Region = configuration["minIo:region"] ?? "us-east-1",
                 AccessKey = configuration["minIo:accessKey"],
                 SecretKey = configuration["minIo:secretKey"],

--- a/src/Eurofurence.App.Server.Services/Images/ImageService.cs
+++ b/src/Eurofurence.App.Server.Services/Images/ImageService.cs
@@ -8,7 +8,6 @@ using Eurofurence.App.Server.Services.Abstractions.Images;
 using SixLabors.ImageSharp;
 using System.IO;
 using System.Linq;
-using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.PixelFormats;
 using Eurofurence.App.Infrastructure.EntityFramework;
 using Eurofurence.App.Server.Services.Abstractions.MinIO;
@@ -110,8 +109,17 @@ namespace Eurofurence.App.Server.Services.Images
 
             var imageFormat = image.Metadata.DecodedImageFormat;
 
+            var guid = Guid.NewGuid();
+
+            var fileName = imageFormat != null
+                ? guid + "." + imageFormat.FileExtensions.FirstOrDefault("png")
+                : guid + ".png";
+
             var record = new ImageRecord
             {
+                Id = guid,
+                InternalFileName = fileName,
+                Url = $"{_minIoClient.Config.Endpoint}/{_minIoConfiguration.Bucket}/{fileName}",
                 InternalReference = internalReference,
                 IsDeleted = 0,
                 MimeType = imageFormat?.DefaultMimeType,
@@ -123,7 +131,7 @@ namespace Eurofurence.App.Server.Services.Images
 
             await base.InsertOneAsync(record);
 
-            await UploadFileToMinIoAsync(_minIoConfiguration.Bucket, record.Id.ToString(),
+            await UploadFileToMinIoAsync(_minIoConfiguration.Bucket, record.InternalFileName,
                 imageFormat?.DefaultMimeType, stream);
 
             await _appDbContext.SaveChangesAsync();
@@ -142,16 +150,24 @@ namespace Eurofurence.App.Server.Services.Images
                 image = Image.Load(byteArray);
             }
 
-            IImageFormat imageFormat = image.Metadata.DecodedImageFormat;
+            var imageFormat = image.Metadata.DecodedImageFormat;
 
             var existingRecord = await
                 _appDbContext.Images
                     .AsNoTracking()
                     .FirstOrDefaultAsync(entity => entity.Id == id);
 
-            await UploadFileToMinIoAsync(_minIoConfiguration.Bucket, existingRecord.Id.ToString(),
+            await DeleteFileFromMinIoAsync(_minIoConfiguration.Bucket, existingRecord.InternalFileName);
+
+            var fileName = imageFormat != null
+                ? existingRecord.Id + "." + imageFormat.FileExtensions.FirstOrDefault("png")
+                : existingRecord.Id + ".png";
+
+            await UploadFileToMinIoAsync(_minIoConfiguration.Bucket, existingRecord.InternalFileName,
                 imageFormat?.DefaultMimeType, stream);
 
+            existingRecord.InternalFileName = fileName;
+            existingRecord.Url = $"{_minIoClient.Config.Endpoint}/{_minIoConfiguration.Bucket}/{fileName}";
             existingRecord.InternalReference = internalReference;
             existingRecord.MimeType = imageFormat?.DefaultMimeType;
             existingRecord.Width = image.Width;
@@ -164,15 +180,20 @@ namespace Eurofurence.App.Server.Services.Images
 
         public async Task<Stream> GetImageContentByImageIdAsync(Guid id)
         {
+            var existingRecord = await
+                _appDbContext.Images
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(entity => entity.Id == id);
+
             // Checks if the object exists
             await _minIoClient.StatObjectAsync(new StatObjectArgs()
                 .WithBucket(_minIoConfiguration.Bucket)
-                .WithObject(id.ToString()));
+                .WithObject(existingRecord.InternalFileName));
 
             var ms = new MemoryStream();
             await _minIoClient.GetObjectAsync(new GetObjectArgs()
                 .WithBucket(_minIoConfiguration.Bucket)
-                .WithObject(id.ToString())
+                .WithObject(existingRecord.InternalFileName)
                 .WithCallbackStream(stream =>
                 {
                     stream.CopyTo(ms);

--- a/src/Eurofurence.App.Server.Services/Images/ImageService.cs
+++ b/src/Eurofurence.App.Server.Services/Images/ImageService.cs
@@ -119,7 +119,7 @@ namespace Eurofurence.App.Server.Services.Images
             {
                 Id = guid,
                 InternalFileName = fileName,
-                Url = $"{_minIoClient.Config.Endpoint}/{_minIoConfiguration.Bucket}/{fileName}",
+                Url = $"{_minIoConfiguration.BaseUrl ?? _minIoClient.Config.BaseUrl}/{_minIoConfiguration.Bucket}/{fileName}",
                 InternalReference = internalReference,
                 IsDeleted = 0,
                 MimeType = imageFormat?.DefaultMimeType,
@@ -167,7 +167,7 @@ namespace Eurofurence.App.Server.Services.Images
                 imageFormat?.DefaultMimeType, stream);
 
             existingRecord.InternalFileName = fileName;
-            existingRecord.Url = $"{_minIoClient.Config.Endpoint}/{_minIoConfiguration.Bucket}/{fileName}";
+            existingRecord.Url = $"{_minIoConfiguration.BaseUrl ?? _minIoClient.Config.BaseUrl}/{_minIoConfiguration.Bucket}/{fileName}";
             existingRecord.InternalReference = internalReference;
             existingRecord.MimeType = imageFormat?.DefaultMimeType;
             existingRecord.Width = image.Width;

--- a/src/Eurofurence.App.Server.Web/Controllers/ImagesController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/ImagesController.cs
@@ -81,6 +81,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         [HttpGet("{id}/Content")]
         [ProducesResponseType(typeof(string), 404)]
         [ProducesResponseType(typeof(byte[]), 200)]
+        [Obsolete("Deprecated. Please use the 'Url' property of the image to stream the image from there instead.")]
         public async Task<ActionResult> GetImageContentAsync([FromRoute] Guid id)
         {
             var record = await _imageService.FindOneAsync(id);
@@ -99,6 +100,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         [ProducesResponseType(typeof(string), 404)]
         [ProducesResponseType(typeof(byte[]), 200)]
         [ResponseCache(Duration = 60 * 60 * 24, Location = ResponseCacheLocation.Any)]
+        [Obsolete("Deprecated. Please use the 'Url' property of the image to stream the image from there instead.")]
         public async Task<ActionResult> GetImageWithHashContentAsync(
             [EnsureNotNull][FromRoute] Guid id,
             [EnsureNotNull][FromRoute] string contentHashBase64Encoded)

--- a/src/Eurofurence.App.Server.Web/Jobs/FlushPrivateMessageNotificationsJob.cs
+++ b/src/Eurofurence.App.Server.Web/Jobs/FlushPrivateMessageNotificationsJob.cs
@@ -22,7 +22,7 @@ namespace Eurofurence.App.Server.Web.Jobs
 
         public Task Execute(IJobExecutionContext context)
         {
-            _logger.LogInformation($"Starting job {context.JobDetail.Key.Name}");
+            _logger.LogDebug($"Starting job {context.JobDetail.Key.Name}");
 
             try
             {

--- a/src/Eurofurence.App.Server.Web/Jobs/UpdateAnnouncementsJob.cs
+++ b/src/Eurofurence.App.Server.Web/Jobs/UpdateAnnouncementsJob.cs
@@ -51,7 +51,7 @@ namespace Eurofurence.App.Server.Web.Jobs
                     var url = _configuration.Url;
                     if (string.IsNullOrWhiteSpace(url))
                     {
-                        _logger.LogError(LogEvents.Import, "Empty source url; cancelling job", url);
+                        _logger.LogError(LogEvents.Import, "Empty source url; cancelling job");
                         return;
                     }
 

--- a/src/Eurofurence.App.Server.Web/Mapper/KnowledgeEntryResponseRegister.cs
+++ b/src/Eurofurence.App.Server.Web/Mapper/KnowledgeEntryResponseRegister.cs
@@ -1,0 +1,20 @@
+﻿using System.Linq;
+using Eurofurence.App.Domain.Model.Images;
+using Eurofurence.App.Domain.Model.Knowledge;
+using Mapster;
+
+namespace Eurofurence.App.Server.Web.Mapper
+{
+    /// <summary>
+    /// Mapping register for mapping IDs of knowledge entry images to the response type
+    /// </summary>
+    public class KnowledgeEntryResponseRegister : IRegister
+    {
+        public void Register(TypeAdapterConfig config)
+        {
+            config
+                .NewConfig<KnowledgeEntryRecord, KnowledgeEntryResponse>()
+                .Map(dest => dest.ImageIds, src => src.Images.Select(ke => ke.Id));
+        }
+    }
+}

--- a/src/Eurofurence.App.Server.Web/appsettings.sample.json
+++ b/src/Eurofurence.App.Server.Web/appsettings.sample.json
@@ -22,7 +22,7 @@
     "baseUrl": "",
     "appIdITunes": 0,
     "appIdPlay": "",
-    "workingDirectory": "/tmp/workingDir" // Working directory to store temporary data, e.g. the dealers export file
+    "workingDirectory": "/tmp/workingDir"
   },
   "logLevel": 1,
   "auditLog": "/tmp/audit.log",
@@ -109,10 +109,11 @@
     "url": ""
   },
   "events": {
-    "url": "" // URL to statically hosted events csv export file
+    "url": ""
   },
   "minIo": {
     "endpoint": "minio:9000",
+    "baseUrl": "http://127.0.0.1:9000",
     "region": "us-east-1",
     "accessKey": "minioAccessKey",
     "secretKey": "minioVerySecretKey",


### PR DESCRIPTION
This PR adds a 'Url' property to the images, aswell as a hidden property "InternalFileName" to save the file name under which the file was uploaded to MinIO.

Using the Url property, images can now be loaded from MinIO directly.

The image content endpoints have been set as deprecated.

Loading the images directly from the MinIO url has been implemented to the Backoffice.