### PR TITLE
feat(rbac): rework access roles

### DIFF
--- a/src/Eurofurence.App.Server.Services/Abstractions/ArtistsAlley/ITableRegistrationService.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/ArtistsAlley/ITableRegistrationService.cs
@@ -6,7 +6,9 @@ using Eurofurence.App.Domain.Model.ArtistsAlley;
 
 namespace Eurofurence.App.Server.Services.Abstractions.ArtistsAlley
 {
-    public interface ITableRegistrationService
+    public interface ITableRegistrationService :
+        IEntityServiceOperations<TableRegistrationRecord>,
+        IPatchOperationProcessor<TableRegistrationRecord>
     {
         Task RegisterTableAsync(ClaimsPrincipal user, TableRegistrationRequest request);
         IQueryable<TableRegistrationRecord> GetRegistrations(TableRegistrationRecord.RegistrationStateEnum? state);

--- a/src/Eurofurence.App.Server.Web/Controllers/AnnouncementsController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/AnnouncementsController.cs
@@ -47,7 +47,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         }
 
         [HttpDelete("{id}")]
-        [Authorize(Roles = "System,Developer")]
+        [Authorize(Roles = "Admin")]
         public async Task<ActionResult> DeleteAnnouncementAsync([FromRoute] Guid id)
         {
             if (await _announcementService.FindOneAsync(id) == null) return NotFound();
@@ -60,7 +60,7 @@ namespace Eurofurence.App.Server.Web.Controllers
 
 
         [HttpPost]
-        [Authorize(Roles = "System,Developer")]
+        [Authorize(Roles = "Admin")]
         public async Task<ActionResult> PostAnnouncementAsync([FromBody] AnnouncementRecord record)
         {
             record.Touch();
@@ -74,7 +74,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         }
 
         [HttpPut]
-        [Authorize(Roles = "System,Developer")]
+        [Authorize(Roles = "Admin")]
         public async Task<ActionResult> PutAnnouncementAsync([FromBody] AnnouncementRecord record)
         {
             if (record == null) return BadRequest("Error parsing Record");
@@ -92,7 +92,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         }
 
         [HttpDelete]
-        [Authorize(Roles = "System,Developer")]
+        [Authorize(Roles = "Admin")]
         public async Task<ActionResult> ClearAnnouncementAsync()
         {
             await _announcementService.DeleteAllAsync();

--- a/src/Eurofurence.App.Server.Web/Controllers/ArtShowController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/ArtShowController.cs
@@ -30,7 +30,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// There's a row-hash built from the mentioned import fields. If a row with the same hash is already present, it will be skipped.
         /// (Importing the same data multiple times does not lead to duplicates.)
         /// </remarks> 
-        [Authorize(Roles = "System,Developer,ArtShow")]
+        [Authorize(Roles = "Admin,ArtShow")]
         [HttpPost("ItemActivites/Log")]
         [ProducesResponseType(201)]
         [BinaryPayload(Description = "Art show log contents")]
@@ -48,7 +48,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// as well as items going into auction (`IdsToAuction`) with their current bid on top. <br /><br />
         /// <b>Calling this endpoint does not modify any data and does not send any messages.</b>
         /// </remarks> 
-        [Authorize(Roles = "System,Developer,ArtShow")]
+        [Authorize(Roles = "Admin,ArtShow")]
         [HttpGet("ItemActivites/NotificationBundles/Simulation")]
         [ProducesResponseType(200)]
         public IList<ItemActivityNotificationResult> SimulateItemActivitiesNotificationRunAsync()
@@ -65,7 +65,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <b><u>Calling this endpoint will produce and queue all notifications/messages for delivery. Notifications are sent asynchronously and in queue,
         /// so full delivery may take a few minutes.</u></b>
         /// </remarks> 
-        [Authorize(Roles = "System,Developer,ArtShow")]
+        [Authorize(Roles = "Admin,ArtShow")]
         [HttpPost("ItemActivites/NotificationBundles/Send")]
         [ProducesResponseType(204)]
         public async Task<ActionResult> ExecuteNotificationRunAsync()
@@ -82,7 +82,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// Deletes any imported data for which no notification has been sent yet.<br /><br />
         /// <b>Use this to remove imported data if the simulation does not check out.</b>
         /// </remarks>
-        [Authorize(Roles = "System,Developer,ArtShow")]
+        [Authorize(Roles = "Admin,ArtShow")]
         [HttpDelete("ItemActivites/NotificationBundles/:unprocessed")]
         [ProducesResponseType(204)]
         public async Task<ActionResult> DeleteUnprocessedItemActivitiesImportRowsAsync()
@@ -100,7 +100,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// There's a row-hash built from the mentioned import fields. If a row with the same hash is already present, it will be skipped.
         /// (Importing the same data multiple times does not lead to duplicates.)
         /// </remarks> 
-        [Authorize(Roles = "System,Developer,ArtShow")]
+        [Authorize(Roles = "Admin,ArtShow")]
         [HttpPost("AgentClosingResults/Log")]
         [ProducesResponseType(201)]
         [BinaryPayload(Description = "Agent closing result log contents")]
@@ -117,7 +117,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// The simulation data shows individual notification data for every agent (`AgentBadgeNo`).<br /><br />
         /// <b>Calling this endpoint does not modify any data and does not send any messages.</b>
         /// </remarks> 
-        [Authorize(Roles = "System,Developer,ArtShow")]
+        [Authorize(Roles = "Admin,ArtShow")]
         [HttpGet("AgentClosingResults/NotificationBundles/Simulation")]
         [ProducesResponseType(200)]
         public IList<AgentClosingNotificationResult> SimulateAgentClosingResultsNotificationRunAsync()
@@ -134,7 +134,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <b><u>Calling this endpoint will produce and queue all notifications/messages for delivery. Notifications are sent asynchronously and in queue,
         /// so full delivery may take a few minutes.</u></b>
         /// </remarks> 
-        [Authorize(Roles = "System,Developer,ArtShow")]
+        [Authorize(Roles = "Admin,ArtShow")]
         [HttpPost("AgentClosingResults/NotificationBundles/Send")]
         [ProducesResponseType(204)]
         public async Task<ActionResult> ExecuteAgentNotificationRunAsync()
@@ -150,7 +150,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// Deletes any imported data for which no notification has been sent yet.<br /><br />
         /// <b>Use this to remove imported data if the simulation does not check out.</b>
         /// </remarks>
-        [Authorize(Roles = "System,Developer,ArtShow")]
+        [Authorize(Roles = "Admin,ArtShow")]
         [HttpDelete("AgentClosingResults/NotificationBundles/:unprocessed")]
         [ProducesResponseType(204)]
         public async Task<ActionResult> DeleteUnprocessedAgentClosingResultsImportRowsAsync()

--- a/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Eurofurence.App.Domain.Model.ArtistsAlley;
 using Eurofurence.App.Server.Services.Abstractions.ArtistsAlley;
 using Eurofurence.App.Server.Services.Abstractions.Security;
 using Eurofurence.App.Server.Web.Extensions;
-using MapsterMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -24,7 +24,6 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     Retrieves a list of all table registrations.
         /// </summary>
         /// <returns>All table registrations.</returns>
-        [HttpGet]
         [ProducesResponseType(typeof(string), 404)]
         [ProducesResponseType(typeof(IEnumerable<TableRegistrationRecord>), 200)]
         [Authorize(Roles = "Admin")]
@@ -32,6 +31,21 @@ namespace Eurofurence.App.Server.Web.Controllers
         public IEnumerable<TableRegistrationRecord> GetTableRegistrationsAsync()
         {
             return _tableRegistrationService.GetRegistrations(null);
+        }
+
+        /// <summary>
+        ///     Retrieve a single table registration.
+        /// </summary>
+        /// <param name="id">id of the requested entity</param>
+        [ProducesResponseType(typeof(string), 404)]
+        [ProducesResponseType(typeof(TableRegistrationRecord), 200)]
+        [Authorize(Roles = "Admin")]
+        [HttpGet("{id}")]
+        public async Task<TableRegistrationRecord> GetTableRegistrationAsync(
+            [EnsureNotNull][FromRoute] Guid id
+        )
+        {
+            return (await _tableRegistrationService.FindOneAsync(id)).Transient404(HttpContext);
         }
 
         [Authorize(Roles = "Attendee")]
@@ -48,6 +62,25 @@ namespace Eurofurence.App.Server.Web.Controllers
         {
             var record = await _tableRegistrationService.GetLatestRegistrationByUidAsync(User.GetSubject());
             return record.Transient404(HttpContext);
+        }
+
+        /// <summary>
+        ///     Delete a table registration..
+        /// </summary>
+        /// <param name="id">The table registration id.</param>
+        /// <returns></returns>
+        [HttpDelete("{id}")]
+        [Authorize(Roles = "Admin")]
+        [ProducesResponseType(204)]
+        [ProducesResponseType(typeof(string), 404)]
+        public async Task<ActionResult> DeleteTableRegistrationAsync([EnsureNotNull][FromRoute] Guid id)
+        {
+            var exists = await _tableRegistrationService.HasOneAsync(id);
+            if (!exists) return NotFound();
+
+            await _tableRegistrationService.DeleteOneAsync(id);
+
+            return NoContent();
         }
     }
 } 

--- a/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
@@ -27,7 +27,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         [HttpGet]
         [ProducesResponseType(typeof(string), 404)]
         [ProducesResponseType(typeof(IEnumerable<TableRegistrationRecord>), 200)]
-        [Authorize(Roles = "System,Developer,Admin")]
+        [Authorize(Roles = "Admin")]
         [HttpGet]
         public IEnumerable<TableRegistrationRecord> GetTableRegistrationsAsync()
         {

--- a/src/Eurofurence.App.Server.Web/Controllers/CommunicationController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/CommunicationController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -91,7 +91,7 @@ namespace Eurofurence.App.Server.Web.Controllers
 
 
         [HttpGet("PrivateMessages/{messageId}/Status")]
-        [Authorize(Roles = "Admin")]
+        [Authorize(Roles = "Admin,PrivateMessageSender")]
         [ProducesResponseType(typeof(PrivateMessageStatus), 200)]
         [ProducesResponseType(typeof(string), 404)]
         public async Task<PrivateMessageStatus> GetPrivateMessageStatusAsync(
@@ -102,7 +102,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         }
 
         [HttpGet("PrivateMessages/:sent-by-me")]
-        [Authorize(Roles = "PrivateMessageSender")]
+        [Authorize]
         [ProducesResponseType(typeof(IEnumerable<PrivateMessageRecord>), 200)]
         public IQueryable<PrivateMessageRecord> GetMySentPrivateMessagesAsync()
         {

--- a/src/Eurofurence.App.Server.Web/Controllers/CommunicationController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/CommunicationController.cs
@@ -74,7 +74,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <param name="Request"></param>
         /// <returns>The `Id` of the message that has been delivered.</returns>
         /// <response code="400">Unable to parse `Request`</response>
-        [Authorize(Roles = "Admin,Action-PrivateMessages-Send")]
+        [Authorize(Roles = "Admin,PrivateMessageSender")]
         [HttpPost("PrivateMessages")]
         [ProducesResponseType(typeof(Guid), 200)]
         public async Task<ActionResult> SendPrivateMessageAsync([FromBody] SendPrivateMessageRequest Request)
@@ -91,7 +91,7 @@ namespace Eurofurence.App.Server.Web.Controllers
 
 
         [HttpGet("PrivateMessages/{messageId}/Status")]
-        [Authorize(Roles = "Admin,Action-PrivateMessages-Query")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(typeof(PrivateMessageStatus), 200)]
         [ProducesResponseType(typeof(string), 404)]
         public async Task<PrivateMessageStatus> GetPrivateMessageStatusAsync(
@@ -102,7 +102,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         }
 
         [HttpGet("PrivateMessages/:sent-by-me")]
-        [Authorize]
+        [Authorize(Roles = "PrivateMessageSender")]
         [ProducesResponseType(typeof(IEnumerable<PrivateMessageRecord>), 200)]
         public IQueryable<PrivateMessageRecord> GetMySentPrivateMessagesAsync()
         {

--- a/src/Eurofurence.App.Server.Web/Controllers/CommunicationController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/CommunicationController.cs
@@ -74,7 +74,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <param name="Request"></param>
         /// <returns>The `Id` of the message that has been delivered.</returns>
         /// <response code="400">Unable to parse `Request`</response>
-        [Authorize(Roles = "Developer,System,Action-PrivateMessages-Send")]
+        [Authorize(Roles = "Admin,Action-PrivateMessages-Send")]
         [HttpPost("PrivateMessages")]
         [ProducesResponseType(typeof(Guid), 200)]
         public async Task<ActionResult> SendPrivateMessageAsync([FromBody] SendPrivateMessageRequest Request)
@@ -91,7 +91,7 @@ namespace Eurofurence.App.Server.Web.Controllers
 
 
         [HttpGet("PrivateMessages/{messageId}/Status")]
-        [Authorize(Roles = "Developer,System,Action-PrivateMessages-Query")]
+        [Authorize(Roles = "Admin,Action-PrivateMessages-Query")]
         [ProducesResponseType(typeof(PrivateMessageStatus), 200)]
         [ProducesResponseType(typeof(string), 404)]
         public async Task<PrivateMessageStatus> GetPrivateMessageStatusAsync(
@@ -110,7 +110,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         }
 
         [HttpGet("NotificationQueue/Count")]
-        [Authorize(Roles = "Developer,System")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(typeof(int), 200)]
         public int GetNotificationQueueSize()
         {

--- a/src/Eurofurence.App.Server.Web/Controllers/DealersController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/DealersController.cs
@@ -57,7 +57,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// </summary>
         /// <param name="record"></param>
         /// <param name="id"></param>
-        [Authorize(Roles = "System,Developer")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(string), 400)]
         [ProducesResponseType(typeof(string), 404)]
@@ -88,7 +88,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// </summary>
         /// <param name="record"></param>
         /// <returns>Id of the newly created dealer</returns>
-        [Authorize(Roles = "System,Developer")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(typeof(Guid), 200)]
         [ProducesResponseType(400)]
         [HttpPost("")]
@@ -116,7 +116,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <param name="id"></param>
         /// <returns></returns>
         [HttpDelete("{id}")]
-        [Authorize(Roles = "System,Developer")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(string), 404)]
         public async Task<ActionResult> DeleteDealerAsync([EnsureNotNull][FromRoute] Guid id)

--- a/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Eurofurence.App.Domain.Model.Events;
 using Eurofurence.App.Server.Services.Abstractions.Events;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Eurofurence.App.Server.Web.Controllers
@@ -22,6 +23,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         [HttpPost]
         [ProducesResponseType(204)]
         [ProducesResponseType(400)]
+        [Authorize(Roles = "Attendee")]
         public async Task<ActionResult> PostEventFeedbackAsync([FromBody]PostEventFeedbackRequest request)
         {
             if (request == null) return BadRequest();

--- a/src/Eurofurence.App.Server.Web/Controllers/FursuitsController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/FursuitsController.cs
@@ -32,7 +32,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     **Not meant to be consumed by the mobile apps**
         /// </remarks>
         /// <param name="registration"></param>
-        [Authorize(Roles = "System,Developer,FursuitBadgeSystem")]
+        [Authorize(Roles = "Admin,FursuitBadgeSystem")]
         [HttpPost("Badges/Registration")]
         [ProducesResponseType(200)]
         [ProducesResponseType(typeof(ApiErrorResult), 400)]
@@ -49,7 +49,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <remarks>
         ///     **Not meant to be consumed by the mobile apps**
         /// </remarks>
-        [Authorize(Roles = "System,Developer,FursuitBadgeSystem")]
+        [Authorize(Roles = "Admin,FursuitBadgeSystem")]
         [HttpGet("Badges")]
         [ProducesResponseType(typeof(IEnumerable<FursuitBadgeRecord>), 200)]
         [ProducesResponseType(401)]
@@ -167,7 +167,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         }
 
 
-        [Authorize(Roles = "Developer,System")]
+        [Authorize(Roles = "Admin")]
         [HttpPost("CollectingGame/Tokens")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(ApiErrorResult), 400)]
@@ -177,7 +177,7 @@ namespace Eurofurence.App.Server.Web.Controllers
                 .AsActionResult();
         }
 
-        [Authorize(Roles = "Developer,System")]
+        [Authorize(Roles = "Admin")]
         [HttpPost("CollectingGame/Tokens/Batch")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(ApiErrorResult), 400)]
@@ -188,7 +188,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         }
 
 
-        [Authorize(Roles = "Developer,System")]
+        [Authorize(Roles = "Admin")]
         [HttpPost("CollectingGame/Recalculate")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(ApiErrorResult), 400)]

--- a/src/Eurofurence.App.Server.Web/Controllers/ImagesController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/ImagesController.cs
@@ -120,22 +120,7 @@ namespace Eurofurence.App.Server.Web.Controllers
             return File(content, record.MimeType);
         }
 
-        [Authorize(Roles = "System,Developer,KnowledgeBase-Maintainer")]
-        [HttpPut("{id}")]
-        public async Task<ActionResult> PutImageAsync([FromRoute] Guid id, IFormFile file)
-        {
-            var record = await _imageService.FindOneAsync(id);
-            if (record == null) return NotFound();
-
-            using (var ms = new MemoryStream())
-            {
-                await file.CopyToAsync(ms);
-                var result = await _imageService.ReplaceImageAsync(record.Id, file.FileName, ms);
-                return Ok(result);
-            }
-        }
-
-        [Authorize(Roles = "System,Developer,KnowledgeBase-Maintainer")]
+        [Authorize(Roles = "Admin,KnowledgeBase-Maintainer")]
         [HttpPost]
         public async Task<ActionResult> PostImageAsync(IFormFile file)
         {
@@ -152,11 +137,26 @@ namespace Eurofurence.App.Server.Web.Controllers
             }
         }
 
+        [Authorize(Roles = "Admin")]
+        [HttpPut("{id}")]
+        public async Task<ActionResult> PutImageAsync([FromRoute] Guid id, IFormFile file)
+        {
+            var record = await _imageService.FindOneAsync(id);
+            if (record == null) return NotFound();
+
+            using (var ms = new MemoryStream())
+            {
+                await file.CopyToAsync(ms);
+                var result = await _imageService.ReplaceImageAsync(record.Id, file.FileName, ms);
+                return Ok(result);
+            }
+        }
+
         /// <summary>
         ///     Delete an image.
         /// </summary>
         /// <param name="id"></param>
-        [Authorize(Roles = "System,Developer,KnowledgeBase-Maintainer")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(string), 404)]
         [HttpDelete("{id}")]

--- a/src/Eurofurence.App.Server.Web/Controllers/ImagesController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/ImagesController.cs
@@ -120,7 +120,7 @@ namespace Eurofurence.App.Server.Web.Controllers
             return File(content, record.MimeType);
         }
 
-        [Authorize(Roles = "Admin,KnowledgeBase-Maintainer")]
+        [Authorize(Roles = "Admin,KnowledgeBaseEditor")]
         [HttpPost]
         public async Task<ActionResult> PostImageAsync(IFormFile file)
         {

--- a/src/Eurofurence.App.Server.Web/Controllers/KnowledgeEntriesController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/KnowledgeEntriesController.cs
@@ -59,7 +59,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// </summary>
         /// <param name="request"></param>
         /// <param name="id"></param>
-        [Authorize(Roles = "System,Developer,KnowledgeBase-Maintainer")]
+        [Authorize(Roles = "Admin,KnowledgeBase-Maintainer")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(string), 404)]
         [EnsureNotNull][HttpPut("{id}")]
@@ -80,7 +80,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// </summary>
         /// <param name="request"></param>
         /// <returns>Id of the newly created knowledge entry</returns>
-        [Authorize(Roles = "System,Developer,KnowledgeBase-Maintainer")]
+        [Authorize(Roles = "Admin,KnowledgeBase-Maintainer")]
         [ProducesResponseType(typeof(Guid), 200)]
         [HttpPost("")]
         public async Task<ActionResult> PostKnowledgeEntryAsync(
@@ -96,7 +96,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     Delete a knowledge entry.
         /// </summary>
         /// <param name="id"></param>
-        [Authorize(Roles = "System,Developer,KnowledgeBase-Maintainer")]
+        [Authorize(Roles = "Admin,KnowledgeBase-Maintainer")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(string), 404)]
         [HttpDelete("{id}")]

--- a/src/Eurofurence.App.Server.Web/Controllers/KnowledgeEntriesController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/KnowledgeEntriesController.cs
@@ -59,7 +59,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// </summary>
         /// <param name="request"></param>
         /// <param name="id"></param>
-        [Authorize(Roles = "Admin,KnowledgeBase-Maintainer")]
+        [Authorize(Roles = "Admin,KnowledgeBaseEditor")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(string), 404)]
         [EnsureNotNull][HttpPut("{id}")]
@@ -80,7 +80,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// </summary>
         /// <param name="request"></param>
         /// <returns>Id of the newly created knowledge entry</returns>
-        [Authorize(Roles = "Admin,KnowledgeBase-Maintainer")]
+        [Authorize(Roles = "Admin,KnowledgeBaseEditor")]
         [ProducesResponseType(typeof(Guid), 200)]
         [HttpPost("")]
         public async Task<ActionResult> PostKnowledgeEntryAsync(
@@ -96,7 +96,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     Delete a knowledge entry.
         /// </summary>
         /// <param name="id"></param>
-        [Authorize(Roles = "Admin,KnowledgeBase-Maintainer")]
+        [Authorize(Roles = "Admin,KnowledgeBaseEditor")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(string), 404)]
         [HttpDelete("{id}")]

--- a/src/Eurofurence.App.Server.Web/Controllers/KnowledgeGroupsController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/KnowledgeGroupsController.cs
@@ -51,7 +51,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// </summary>
         /// <param name="record"></param>
         /// <param name="id"></param>
-        [Authorize(Roles = "System,Developer,KnowledgeBase-Maintainer")]
+        [Authorize(Roles = "Admin,KnowledgeBase-Maintainer")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(string), 404)]
         [HttpPut("{id}")]
@@ -74,7 +74,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// </summary>
         /// <param name="Record"></param>
         /// <returns>Id of the newly created knowledge group</returns>
-        [Authorize(Roles = "System,Developer,KnowledgeBase-Maintainer")]
+        [Authorize(Roles = "Admin,KnowledgeBase-Maintainer")]
         [ProducesResponseType(typeof(Guid), 200)]
         [HttpPost("")]
         public async Task<ActionResult> PostKnowledgeGroupAsync(
@@ -92,7 +92,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     Delete a knowledge group.
         /// </summary>
         /// <param name="id"></param>
-        [Authorize(Roles = "System,Developer,KnowledgeBase-Maintainer")]
+        [Authorize(Roles = "Admin,KnowledgeBase-Maintainer")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(string), 404)]
         [HttpDelete("{id}")]

--- a/src/Eurofurence.App.Server.Web/Controllers/KnowledgeGroupsController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/KnowledgeGroupsController.cs
@@ -51,7 +51,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// </summary>
         /// <param name="record"></param>
         /// <param name="id"></param>
-        [Authorize(Roles = "Admin,KnowledgeBase-Maintainer")]
+        [Authorize(Roles = "Admin,KnowledgeBaseEditor")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(string), 404)]
         [HttpPut("{id}")]
@@ -74,7 +74,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// </summary>
         /// <param name="Record"></param>
         /// <returns>Id of the newly created knowledge group</returns>
-        [Authorize(Roles = "Admin,KnowledgeBase-Maintainer")]
+        [Authorize(Roles = "Admin,KnowledgeBaseEditor")]
         [ProducesResponseType(typeof(Guid), 200)]
         [HttpPost("")]
         public async Task<ActionResult> PostKnowledgeGroupAsync(
@@ -92,7 +92,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     Delete a knowledge group.
         /// </summary>
         /// <param name="id"></param>
-        [Authorize(Roles = "Admin,KnowledgeBase-Maintainer")]
+        [Authorize(Roles = "Admin,KnowledgeBaseEditor")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(string), 404)]
         [HttpDelete("{id}")]

--- a/src/Eurofurence.App.Server.Web/Controllers/MapsController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/MapsController.cs
@@ -123,7 +123,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     * No map found for the given `id`
         /// </response>
         [HttpDelete("{id}/Entries")]
-        [Authorize(Roles = "Admin")]
+        [Authorize(Roles = "Admin,MapEditor")]
         [ProducesResponseType(204)]
         public async Task<ActionResult> DeleteMapEntriesAsync([FromRoute] Guid id)
         {
@@ -145,7 +145,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     * No map found for the given `id`
         /// </response>
         [HttpDelete("{id}/Entries/{entryId}")]
-        [Authorize(Roles = "Admin")]
+        [Authorize(Roles = "Admin,MapEditor")]
         [ProducesResponseType(204)]
         public async Task<ActionResult> DeleteSingleMapEntryAsync([FromRoute] Guid id, [FromRoute] Guid entryId)
         {
@@ -174,7 +174,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     * Unable to parse `record` or `id`
         /// </response>
         [HttpPost("{id}/Entries")]
-        [Authorize(Roles = "Admin")]
+        [Authorize(Roles = "Admin,MapEditor")]
         [ProducesResponseType(typeof(Guid), 200)]
         public async Task<ActionResult> PostSingleMapEntryAsync([FromBody] MapEntryRecord record, [FromRoute] Guid id)
         {
@@ -207,7 +207,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     * No map found with for the specified id.
         /// </response>
         [HttpPut("{id}/Entries/{entryId}")]
-        [Authorize(Roles = "Admin")]
+        [Authorize(Roles = "Admin,MapEditor")]
         [ProducesResponseType(typeof(Guid), 200)]
         public async Task<ActionResult> PutSingleMapEntryAsync([FromBody] MapEntryRecord record, [FromRoute] Guid id,
             [FromRoute] Guid entryId)

--- a/src/Eurofurence.App.Server.Web/Controllers/MapsController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/MapsController.cs
@@ -6,7 +6,6 @@ using Eurofurence.App.Domain.Model.Maps;
 using Eurofurence.App.Server.Services.Abstractions.Maps;
 using Eurofurence.App.Server.Services.Abstractions.Validation;
 using Eurofurence.App.Server.Web.Extensions;
-using MapsterMapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -85,7 +84,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// </summary>
         /// <param name="record"></param>
         /// <returns>Id of the newly created map</returns>
-        [Authorize(Roles = "Admin,Developer")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(typeof(Guid), 200)]
         [HttpPost("")]
         public async Task<ActionResult> PostMapAsync(
@@ -100,7 +99,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     Delete a map.
         /// </summary>
         /// <param name="id"></param>
-        [Authorize(Roles = "Admin,Developer")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(204)]
         [ProducesResponseType(typeof(string), 404)]
         [HttpDelete("{id}")]
@@ -124,7 +123,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     * No map found for the given `id`
         /// </response>
         [HttpDelete("{id}/Entries")]
-        [Authorize(Roles = "Admin,Developer")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(204)]
         public async Task<ActionResult> DeleteMapEntriesAsync([FromRoute] Guid id)
         {
@@ -146,7 +145,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     * No map found for the given `id`
         /// </response>
         [HttpDelete("{id}/Entries/{entryId}")]
-        [Authorize(Roles = "Admin,Developer")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(204)]
         public async Task<ActionResult> DeleteSingleMapEntryAsync([FromRoute] Guid id, [FromRoute] Guid entryId)
         {
@@ -175,7 +174,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     * Unable to parse `record` or `id`
         /// </response>
         [HttpPost("{id}/Entries")]
-        [Authorize(Roles = "Admin,Developer")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(typeof(Guid), 200)]
         public async Task<ActionResult> PostSingleMapEntryAsync([FromBody] MapEntryRecord record, [FromRoute] Guid id)
         {
@@ -208,7 +207,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         ///     * No map found with for the specified id.
         /// </response>
         [HttpPut("{id}/Entries/{entryId}")]
-        [Authorize(Roles = "Admin,Developer")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(typeof(Guid), 200)]
         public async Task<ActionResult> PutSingleMapEntryAsync([FromBody] MapEntryRecord record, [FromRoute] Guid id,
             [FromRoute] Guid entryId)

--- a/src/Eurofurence.App.Server.Web/Controllers/PushNotificationsController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/PushNotificationsController.cs
@@ -29,7 +29,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         }
 
         [HttpPost("SyncRequest")]
-        [Authorize(Roles = "System,Developer")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(204)]
         public async Task<ActionResult> PushSyncRequestAsync()
         {
@@ -38,7 +38,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         }
 
         [HttpPost("WnsToast")]
-        [Authorize(Roles = "Developer")]
+        [Authorize(Roles = "Admin")]
         public async Task<ActionResult> PostWnsToastAsync([FromBody] ToastTest request)
         {
             await _wnsChannelManager.SendToastAsync(request.Topic, request.Message);
@@ -69,7 +69,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         }
 
         [HttpGet("Statistics")]
-        [Authorize(Roles = "Developer")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(typeof(PushNotificationChannelStatistics), 200)]
         public async Task<PushNotificationChannelStatistics> GetStatisticsAsync([FromQuery] DateTime? Since)
         {

--- a/src/Eurofurence.App.Server.Web/Identity/AuthorizationOptions.cs
+++ b/src/Eurofurence.App.Server.Web/Identity/AuthorizationOptions.cs
@@ -8,13 +8,13 @@ public class AuthorizationOptions
 
     public HashSet<string> Admin { get; set; } = new();
 
-    public HashSet<string> KnowledgeBaseMaintainer { get; set; } = new();
-    
+    public HashSet<string> KnowledgeBaseEditor { get; set; } = new();
+
+    public HashSet<string> MapEditor { get; set; } = new();
+
     public HashSet<string> ArtShow { get; set; } = new();
     
     public HashSet<string> FursuitBadgeSystem { get; set; } = new();
     
-    public HashSet<string> PrivateMessagesSend { get; set; } = new();
-    
-    public HashSet<string> PrivateMessagesQuery { get; set; } = new();
+    public HashSet<string> PrivateMessageSender { get; set; } = new();
 }

--- a/src/Eurofurence.App.Server.Web/Identity/AuthorizationOptions.cs
+++ b/src/Eurofurence.App.Server.Web/Identity/AuthorizationOptions.cs
@@ -5,12 +5,8 @@ namespace Eurofurence.App.Server.Web.Identity;
 public class AuthorizationOptions
 {
     public HashSet<string> Attendee { get; set; } = new();
-    
-    public HashSet<string> System { get; set; } = new();
-    
-    public HashSet<string> Admin { get; set; } = new();
 
-    public HashSet<string> Developer { get; set; } = new();
+    public HashSet<string> Admin { get; set; } = new();
 
     public HashSet<string> KnowledgeBaseMaintainer { get; set; } = new();
     

--- a/src/Eurofurence.App.Server.Web/Identity/RolesClaimsTransformation.cs
+++ b/src/Eurofurence.App.Server.Web/Identity/RolesClaimsTransformation.cs
@@ -24,35 +24,35 @@ public class RolesClaimsTransformation(IOptionsSnapshot<AuthorizationOptions> op
             {
                 roles.Add("Attendee");
             }
-            
-            if (options.Value.Admin.Contains(claim.Value))
-            {
-                roles.Add("Admin");
-            }
-            
-            if (options.Value.KnowledgeBaseMaintainer.Contains(claim.Value))
-            {
-                roles.Add("KnowledgeBase-Maintainer");
-            }
 
             if (options.Value.ArtShow.Contains(claim.Value))
             {
                 roles.Add("ArtShow");
+            }
+
+            if (options.Value.PrivateMessageSender.Contains(claim.Value))
+            {
+                roles.Add("PrivateMessageSender");
+            }
+            
+            if (options.Value.KnowledgeBaseEditor.Contains(claim.Value))
+            {
+                roles.Add("KnowledgeBaseEditor");
+            }
+
+            if (options.Value.MapEditor.Contains(claim.Value))
+            {
+                roles.Add("MapEditor");
             }
             
             if (options.Value.FursuitBadgeSystem.Contains(claim.Value))
             {
                 roles.Add("FursuitBadgeSystem");
             }
-            
-            if (options.Value.PrivateMessagesSend.Contains(claim.Value))
+
+            if (options.Value.Admin.Contains(claim.Value))
             {
-                roles.Add("Action-PrivateMessages-Send");
-            }
-            
-            if (options.Value.PrivateMessagesQuery.Contains(claim.Value))
-            {
-                roles.Add("Action-PrivateMessages-Query");
+                roles.Add("Admin");
             }
         }
 

--- a/src/Eurofurence.App.Server.Web/Identity/RolesClaimsTransformation.cs
+++ b/src/Eurofurence.App.Server.Web/Identity/RolesClaimsTransformation.cs
@@ -30,16 +30,6 @@ public class RolesClaimsTransformation(IOptionsSnapshot<AuthorizationOptions> op
                 roles.Add("Admin");
             }
             
-            if (options.Value.System.Contains(claim.Value))
-            {
-                roles.Add("System");
-            }
-
-            if (options.Value.Developer.Contains(claim.Value))
-            {
-                roles.Add("Developer");
-            }
-
             if (options.Value.KnowledgeBaseMaintainer.Contains(claim.Value))
             {
                 roles.Add("KnowledgeBase-Maintainer");

--- a/src/Eurofurence.App.Server.Web/appsettings.sample.json
+++ b/src/Eurofurence.App.Server.Web/appsettings.sample.json
@@ -6,14 +6,12 @@
   },
   "Authorization": {
     "Attendee": [],
-    "System": [],
-    "Admin": [],
-    "Developer": [],
     "KnowledgeBaseMaintainer": [],
     "ArtShow": [],
     "FursuitBadgeSystem": [],
     "PrivateMessagesSend": [],
-    "PrivateMessagesQuery": []
+    "PrivateMessagesQuery": [],
+    "Admin": []
   },
   "global": {
     "conventionNumber": 99,

--- a/src/Eurofurence.App.Server.Web/appsettings.sample.json
+++ b/src/Eurofurence.App.Server.Web/appsettings.sample.json
@@ -6,11 +6,11 @@
   },
   "Authorization": {
     "Attendee": [],
-    "KnowledgeBaseMaintainer": [],
     "ArtShow": [],
+    "PrivateMessageSender": [],
+    "KnowledgeBaseEditor": [],
+    "MapEditor": [],
     "FursuitBadgeSystem": [],
-    "PrivateMessagesSend": [],
-    "PrivateMessagesQuery": [],
     "Admin": []
   },
   "global": {


### PR DESCRIPTION
The roles and their access were reworked according to the guideline (see #143).

Also, new API endpoints restricted to Admins were added, for querying a single artist alley table registration and deleting a table registration.