### PR TITLE
Fixed a XXS vulnerability on the knowledgebase page:

### DIFF
--- a/src/Eurofurence.App.Backoffice/Components/KnowledgeEntryDialog.razor
+++ b/src/Eurofurence.App.Backoffice/Components/KnowledgeEntryDialog.razor
@@ -38,7 +38,7 @@
                                             </CardHeaderContent>
                                         </MudCardHeader>
                                         <MudCardContent>
-                                            <MudText>@((MarkupString) new HtmlSanitizer().Sanitize(_markdownHtml)))</MudText>
+                                            <MudText>@((MarkupString) _htmlSanitizer.Sanitize(_markdownHtml)))</MudText>
                                         </MudCardContent>
                                     </MudCard>
                                 </MudItem>
@@ -125,6 +125,8 @@
 
     private bool _formIsValid;
     private MudForm? _form;
+    
+    private HtmlSanitizer _htmlSanitizer = new HtmlSanitizer();
 
     string _markdownHtml = string.Empty;
 
@@ -145,7 +147,7 @@
             SelectedGroupRecord = _knowledgeGroups.FirstOrDefault(knowledgeGroup => knowledgeGroup.Id == Record?.KnowledgeGroupId);
         }
     }
-
+    
     private async Task UploadImage(IBrowserFile? file)
     {
         if (file == null)

--- a/src/Eurofurence.App.Backoffice/Components/KnowledgeEntryDialog.razor
+++ b/src/Eurofurence.App.Backoffice/Components/KnowledgeEntryDialog.razor
@@ -2,6 +2,7 @@
 @using Eurofurence.App.Backoffice.Services
 @using Eurofurence.App.Domain.Model.Fragments
 @using Eurofurence.App.Domain.Model.Images
+@using Ganss.Xss
 @inject ISnackbar Snackbar
 @inject IKnowledgeService KnowledgeService
 @inject IImageService ImageService
@@ -37,7 +38,7 @@
                                             </CardHeaderContent>
                                         </MudCardHeader>
                                         <MudCardContent>
-                                            <MudText>@((MarkupString)_markdownHtml)</MudText>
+                                            <MudText>@((MarkupString) new HtmlSanitizer().Sanitize(_markdownHtml)))</MudText>
                                         </MudCardContent>
                                     </MudCard>
                                 </MudItem>

--- a/src/Eurofurence.App.Backoffice/Eurofurence.App.Backoffice.csproj
+++ b/src/Eurofurence.App.Backoffice/Eurofurence.App.Backoffice.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="HtmlSanitizer" Version="8.2.871-beta" />
     <PackageReference Include="Markdig" Version="0.37.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.7" />

--- a/src/Eurofurence.App.Backoffice/Eurofurence.App.Backoffice.csproj
+++ b/src/Eurofurence.App.Backoffice/Eurofurence.App.Backoffice.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlSanitizer" Version="8.2.871-beta" />
+    <PackageReference Include="HtmlSanitizer" Version="8.1.870" />
     <PackageReference Include="Markdig" Version="0.37.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.7" />

--- a/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
@@ -100,7 +100,7 @@
                         </CardHeaderActions>
                     </MudCardHeader>
                     <MudCardContent>
-                        <MudText Class="mb-4">@((MarkupString)new HtmlSanitizer().Sanitize(Markdown.ToHtml(knowledgeEntry.Text)))</MudText>
+                        <MudText Class="mb-4">@((MarkupString)_htmlSanitizer.Sanitize(Markdown.ToHtml(knowledgeEntry.Text)))</MudText>
 
                         @foreach (var image in knowledgeEntry.Images)
                         {
@@ -126,6 +126,8 @@
     private List<KnowledgeGroupRecord> _knowledgeGroups = new List<KnowledgeGroupRecord>();
     private List<KnowledgeEntryRecord> _knowledgeEntries = new List<KnowledgeEntryRecord>();
 
+    private HtmlSanitizer _htmlSanitizer = new HtmlSanitizer();
+    
     protected override async Task OnInitializedAsync()
     {
         await LoadKnowledgeEntries();

--- a/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
@@ -4,6 +4,7 @@
 @using Microsoft.AspNetCore.Authorization
 @using Eurofurence.App.Backoffice.Components
 @using Eurofurence.App.Domain.Model.Images
+@using Ganss.Xss
 @using Markdig
 @attribute [Authorize]
 @inject ISnackbar Snackbar
@@ -99,7 +100,7 @@
                         </CardHeaderActions>
                     </MudCardHeader>
                     <MudCardContent>
-                        <MudText Class="mb-4">@((MarkupString)Markdown.ToHtml(knowledgeEntry.Text))</MudText>
+                        <MudText Class="mb-4">@((MarkupString)new HtmlSanitizer().Sanitize(Markdown.ToHtml(knowledgeEntry.Text)))</MudText>
 
                         @foreach (var image in knowledgeEntry.Images)
                         {


### PR DESCRIPTION
I have managed to produce a XSS attack on the knowledgebase site.

It happened when creating new entries, editing and viewing existing ones

When the stored MD code was converted into HTML the output was not sanitized properly and therefore code execution was possible.

This PR should fix this issue at the places I found and sanitizing the HTML output. 