### PR TITLE
168 fix entities being listed as changed due to import

### DIFF
--- a/src/Eurofurence.App.Backoffice/Authentication/BackendAccountClaimsFactory.cs
+++ b/src/Eurofurence.App.Backoffice/Authentication/BackendAccountClaimsFactory.cs
@@ -5,27 +5,29 @@ using Microsoft.AspNetCore.Components.WebAssembly.Authentication.Internal;
 
 namespace Eurofurence.App.Backoffice.Authentication
 {
-	public class BackendAccountClaimsFactory : AccountClaimsPrincipalFactory<RemoteUserAccount>
-	{
-		public IServiceProvider _serviceProvider { get; set; }
+    public class BackendAccountClaimsFactory : AccountClaimsPrincipalFactory<RemoteUserAccount>
+    {
+        public IServiceProvider _serviceProvider { get; set; }
 
-		public BackendAccountClaimsFactory(IServiceProvider serviceProvider, IAccessTokenProviderAccessor accessor) : base(accessor)
-		{
-			_serviceProvider = serviceProvider;
-		}
+        public BackendAccountClaimsFactory(IServiceProvider serviceProvider, IAccessTokenProviderAccessor accessor) :
+            base(accessor)
+        {
+            _serviceProvider = serviceProvider;
+        }
 
-		public override async ValueTask<ClaimsPrincipal> CreateUserAsync(RemoteUserAccount account, RemoteAuthenticationUserOptions options)
-		{
-			var userAccount = await base.CreateUserAsync(account, options);
+        public override async ValueTask<ClaimsPrincipal> CreateUserAsync(RemoteUserAccount account,
+            RemoteAuthenticationUserOptions options)
+        {
+            var userAccount = await base.CreateUserAsync(account, options);
 
-			if (!(userAccount.Identity?.IsAuthenticated ?? false))
-			{
-				return userAccount;
-			}
+            if (!(userAccount.Identity?.IsAuthenticated ?? false))
+            {
+                return userAccount;
+            }
 
-			if (userAccount.Identity is ClaimsIdentity identity)
-			{
-				var usersService = _serviceProvider.GetRequiredService<IUserService>();
+            if (userAccount.Identity is ClaimsIdentity identity)
+            {
+                var usersService = _serviceProvider.GetRequiredService<IUserService>();
                 try
                 {
                     var userRecord = await usersService.GetUserSelf();
@@ -34,16 +36,14 @@ namespace Eurofurence.App.Backoffice.Authentication
                         identity.AddClaim(new Claim(identity.RoleClaimType, role));
                     }
                 }
-				catch (AccessTokenNotAvailableException)
+                catch (AccessTokenNotAvailableException)
                 {
                     // No token, no user record
                     // AccessTokenNotAvailableException is ignored here because it will be handled by the TokenAuthorizationMessageHandler
                 }
             }
 
-			return userAccount;
-
-		}
-	}
-
+            return userAccount;
+        }
+    }
 }

--- a/src/Eurofurence.App.Backoffice/Authentication/BackendAccountClaimsFactory.cs
+++ b/src/Eurofurence.App.Backoffice/Authentication/BackendAccountClaimsFactory.cs
@@ -25,13 +25,21 @@ namespace Eurofurence.App.Backoffice.Authentication
 
 			if (userAccount.Identity is ClaimsIdentity identity)
 			{
-				var usersService = _serviceProvider.GetRequiredService<IUsersService>();
-				var userRecord = await usersService.GetUserSelf();
-				foreach (var role in userRecord.Roles)
-				{
-					identity.AddClaim(new Claim(identity.RoleClaimType, role));
-				}
-			}
+				var usersService = _serviceProvider.GetRequiredService<IUserService>();
+                try
+                {
+                    var userRecord = await usersService.GetUserSelf();
+                    foreach (var role in userRecord.Roles)
+                    {
+                        identity.AddClaim(new Claim(identity.RoleClaimType, role));
+                    }
+                }
+				catch (AccessTokenNotAvailableException)
+                {
+                    // No token, no user record
+                    // AccessTokenNotAvailableException is ignored here because it will be handled by the TokenAuthorizationMessageHandler
+                }
+            }
 
 			return userAccount;
 

--- a/src/Eurofurence.App.Backoffice/Authentication/TokenAuthorizationMessageHandler.cs
+++ b/src/Eurofurence.App.Backoffice/Authentication/TokenAuthorizationMessageHandler.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Security.Authentication;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 
 namespace Eurofurence.App.Backoffice.Authentication
@@ -8,6 +9,19 @@ namespace Eurofurence.App.Backoffice.Authentication
         public TokenAuthorizationMessageHandler(IAccessTokenProvider provider, NavigationManager navigation, IConfiguration configuration) : base(provider, navigation)
         {
             ConfigureHandler(new[] { configuration.GetValue<string>("ApiUrl") ?? string.Empty });
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return await base.SendAsync(request, cancellationToken);
+            }
+            catch (AccessTokenNotAvailableException ex)
+            {
+                ex.Redirect();
+                throw new AuthenticationException("Authentication has expired. Redirecting to login...");
+            }
         }
     }
 }

--- a/src/Eurofurence.App.Backoffice/Authentication/TokenAuthorizationMessageHandler.cs
+++ b/src/Eurofurence.App.Backoffice/Authentication/TokenAuthorizationMessageHandler.cs
@@ -1,6 +1,7 @@
-﻿using System.Security.Authentication;
-using Microsoft.AspNetCore.Components;
+﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+
+namespace Eurofurence.App.Backoffice.Authentication;
 
 public class TokenAuthorizationMessageHandler : DelegatingHandler
 {
@@ -30,19 +31,6 @@ public class TokenAuthorizationMessageHandler : DelegatingHandler
                 _navigation.NavigateTo("authentication/login");
             }
             throw new AccessTokenNotAvailableException(_navigation, result, null);
-        }
-
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            try
-            {
-                return await base.SendAsync(request, cancellationToken);
-            }
-            catch (AccessTokenNotAvailableException ex)
-            {
-                ex.Redirect();
-                throw new AuthenticationException("Authentication has expired. Redirecting to login...");
-            }
         }
     }
 }

--- a/src/Eurofurence.App.Backoffice/Layout/RedirectToLogin.razor
+++ b/src/Eurofurence.App.Backoffice/Layout/RedirectToLogin.razor
@@ -4,6 +4,6 @@
 @code {
     protected override void OnInitialized()
     {
-        Navigation.NavigateToLogin("authentication/login");
+        Navigation.NavigateTo("authentication/login");
     }
 }

--- a/src/Eurofurence.App.Backoffice/Program.cs
+++ b/src/Eurofurence.App.Backoffice/Program.cs
@@ -18,7 +18,7 @@ builder.Services.AddScoped<IImageService, ImageService>();
 builder.Services.AddScoped<IArtistAlleyService, ArtistAlleyService>();
 builder.Services.AddScoped<IFursuitService, FursuitService>();
 builder.Services.AddScoped<IDealerService, DealerService>();
-builder.Services.AddScoped<IUsersService, UsersService>();
+builder.Services.AddScoped<IUserService, UserService>();
 
 builder.Services.AddScoped<TokenAuthorizationMessageHandler>();
 builder.Services.AddHttpClient("api", options =>

--- a/src/Eurofurence.App.Backoffice/Services/IUserService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/IUserService.cs
@@ -2,7 +2,7 @@
 
 namespace Eurofurence.App.Backoffice.Services
 {
-    public interface IUsersService
+    public interface IUserService
     {
         public Task<UserRecord> GetUserSelf();
     }

--- a/src/Eurofurence.App.Backoffice/Services/UserService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/UserService.cs
@@ -5,7 +5,7 @@ using Eurofurence.App.Domain.Model.Users;
 
 namespace Eurofurence.App.Backoffice.Services
 {
-	public class UsersService(HttpClient http) : IUsersService
+	public class UserService(HttpClient http) : IUserService
 	{
 		public async Task<UserRecord> GetUserSelf()
 		{

--- a/src/Eurofurence.App.Backoffice/wwwroot/index.html
+++ b/src/Eurofurence.App.Backoffice/wwwroot/index.html
@@ -9,7 +9,6 @@
     <link rel="stylesheet" href="css/app.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <link href="Eurofurence.App.Backoffice.styles.css" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link href="css/tiny-mde.min.css" rel="stylesheet" />
 </head>

--- a/src/Eurofurence.App.Common/DataDiffUtils/PatchDefinition.cs
+++ b/src/Eurofurence.App.Common/DataDiffUtils/PatchDefinition.cs
@@ -4,17 +4,19 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Eurofurence.App.Common.Abstractions;
 
 namespace Eurofurence.App.Common.DataDiffUtils
 {
     public class PatchDefinition<TSource, TTarget> where TTarget : IEntityBase, new()
     {
-        private readonly List<PatchOperator<TSource, TTarget>> _operators = new List<PatchOperator<TSource, TTarget>>();
+        private readonly List<PatchOperator<TSource, TTarget>> _operators = [];
         private readonly Func<TSource, IEnumerable<TTarget>, TTarget> _targetItemLocator;
 
         /// <param name="targetItemLocator">
-        ///     A selector that, inside an enumerable of TTarget, finds the
+        ///     A selector that, inside an IEnumerable of TTarget, finds the
         ///     single TTarget that corresponds to the provided TSource
         /// </param>
         public PatchDefinition(Func<TSource, IEnumerable<TTarget>, TTarget> targetItemLocator)
@@ -22,7 +24,7 @@ namespace Eurofurence.App.Common.DataDiffUtils
             _targetItemLocator = targetItemLocator;
         }
 
-        private bool ArraysEqual(Array a1, Array a2)
+        private static bool ArraysEqual(Array a1, Array a2)
         {
             if (a1.Length == a2.Length)
             {
@@ -37,6 +39,35 @@ namespace Eurofurence.App.Common.DataDiffUtils
                 return true;
             }
             return false;
+        }
+
+        private static bool CollectionsEqual(ICollection collection1, ICollection collection2)
+        {
+            if (collection1.Count == collection2.Count)
+            {
+                var a1e = collection1.GetEnumerator();
+                var a2e = collection2.GetEnumerator();
+
+                for (int i = 0; i < collection1.Count; i++)
+                {
+                    if (!a1e.MoveNext() || !a2e.MoveNext())
+                    {
+                        return false;
+                    }
+
+                    if (!a1e.Current.Equals(a2e.Current))
+                        return false;
+                }
+                return true;
+            }
+            return false;
+        }
+
+        private static bool DictionariesEqual(IDictionary dictionary1, IDictionary dictionary2)
+        {
+            var string1 = JsonSerializer.Serialize(dictionary1);
+            var string2 = JsonSerializer.Serialize(dictionary2);
+            return string1 == string2;
         }
 
         public PatchDefinition<TSource, TTarget> Map<TField>(
@@ -54,21 +85,29 @@ namespace Eurofurence.App.Common.DataDiffUtils
                     if (sourceValue == null && targetValue == null)
                         return true;
 
-                    if (sourceValue == null && targetValue != null || sourceValue != null && targetValue == null)
+                    if (sourceValue == null || targetValue == null)
                         return false;
 
                     if (sourceValue.GetType().IsArray)
                         return ArraysEqual((sourceValue as Array), (targetValue as Array));
 
-                    return sourceValue?.Equals(targetValue) ?? false;
+                    if (sourceValue is IDictionary &&
+                        sourceValue.GetType().IsGenericType)
+                        return DictionariesEqual((IDictionary)sourceValue, (IDictionary)targetValue);
+
+                    if (sourceValue is ICollection &&
+                        sourceValue.GetType().IsGenericType)
+                        return CollectionsEqual((ICollection)sourceValue, (ICollection)targetValue);
+                     
+                    return (bool)sourceValue?.Equals(targetValue);
                 },
                 ApplySourceValueToTarget =
                     (source, target) =>
                     {
                         var value = sourceValueSelector(source);
-                        var memberSelectorExpression = targetSelector.Body as MemberExpression;
+                        if (targetSelector.Body is not MemberExpression memberSelectorExpression) return;
                         var property = memberSelectorExpression.Member as PropertyInfo;
-                        property.SetValue(target, value, null);
+                        if (property != null) property.SetValue(target, value, null);
                     }
             };
 
@@ -84,10 +123,11 @@ namespace Eurofurence.App.Common.DataDiffUtils
 
             var unprocessedTargets = targets.ToList();
             var newTargets = new List<TTarget>();
+            if (newTargets == null) throw new ArgumentNullException(nameof(newTargets));
 
             foreach (var sourceItem in sources)
             {
-                var target = default(TTarget);
+                TTarget target;
 
                 var result = new PatchOperation<TTarget> {Action = ActionEnum.NotModified};
 
@@ -107,10 +147,8 @@ namespace Eurofurence.App.Common.DataDiffUtils
 
                 result.Entity = target;
 
-                foreach (var o in _operators)
+                foreach (var o in _operators.Where(o => !o.IsEqual(sourceItem, target)))
                 {
-                    if (o.IsEqual(sourceItem, target)) continue;
-
                     if (result.Action == ActionEnum.NotModified)
                         result.Action = ActionEnum.Update;
 
@@ -120,12 +158,7 @@ namespace Eurofurence.App.Common.DataDiffUtils
                 patchResults.Add(result);
             }
 
-            foreach (var targetItem in unprocessedTargets)
-                patchResults.Add(new PatchOperation<TTarget>
-                {
-                    Action = ActionEnum.Delete,
-                    Entity = targetItem
-                });
+            patchResults.AddRange(unprocessedTargets.Select(targetItem => new PatchOperation<TTarget> { Action = ActionEnum.Delete, Entity = targetItem }));
 
             return patchResults;
         }


### PR DESCRIPTION
This PR fixes a bug where entities were flagged as updated during the imports, although they haven't been changed, which would have caused more loading times for the app.

It also removes the Google font from the Backoffice and fixes errors when the token expires when using the backoffice, now it will redirect to the login instead.