### PR TITLE
feat(backoffice): manage artist alley registrations (#160)

### DIFF
--- a/src/Eurofurence.App.Backoffice/Components/ArtistAlleyApplicationDialog.razor
+++ b/src/Eurofurence.App.Backoffice/Components/ArtistAlleyApplicationDialog.razor
@@ -1,0 +1,81 @@
+@using Eurofurence.App.Backoffice.Services
+@using Eurofurence.App.Domain.Model.ArtistsAlley
+
+@inject IArtistAlleyService TableRegService
+@inject IDialogService DialogService
+@inject ISnackbar Snackbar
+
+<MudDialog>
+    <DialogContent>
+        <MudContainer Class="overflow-scroll pr-4">
+            <MudGrid>
+                <MudItem>
+                    <MudImage ObjectFit="ObjectFit.Contain" Height="500" Width="500" Class="ml-2" Src="@Record.Image.Url">
+                        @if (string.IsNullOrEmpty(@Record.Image.Url))
+                        {
+                            <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
+                        }
+                    </MudImage>
+                </MudItem>
+
+                <MudItem xs="6">
+                    <MudTextField ReadOnly="true" Value="Record.Id" Label="ID"/>
+                    <MudTextField ReadOnly="true" Value="Record.CreatedDateTimeUtc" Label="Application submitted at"/>
+                    <MudTextField ReadOnly="true" Value="Record.OwnerUid" Label="Applicant UID"/>
+                    <MudTextField ReadOnly="true" Value="Record.OwnerUsername" Label="Applicant's username"/>
+                    <MudTextField ReadOnly="true" Value="Record.WebsiteUrl" Label="Applicants Website"/>
+                    <MudTextField ReadOnly="true" AutoGrow Value="Record.ShortDescription" Label="Short Description"/>
+                    <MudTextField ReadOnly="true" Value="Record.TelegramHandle" Label="Applicant's Telegram handle"/>
+                    <MudTextField ReadOnly="true" Value="Record.Location" Label="Location"/>
+                    @switch (Record.State)
+                    {
+                        case TableRegistrationRecord.RegistrationStateEnum.Pending:
+                            <MudAlert Severity="Severity.Info">Pending</MudAlert>
+                            <MudButton StartIcon="@Icons.Material.Filled.CheckCircle" @onclick="() => TryChangeRegistrationStatus(Record, false)">Approve</MudButton>
+                            <MudButton StartIcon="@Icons.Material.Filled.Cancel" @onclick="() => TryChangeRegistrationStatus(Record, true)">Reject</MudButton>
+                            break;
+                        case TableRegistrationRecord.RegistrationStateEnum.Accepted:
+                            <MudAlert Severity="Severity.Success">Accepted</MudAlert>
+                            break;
+                        case TableRegistrationRecord.RegistrationStateEnum.Rejected:
+                            <MudAlert Severity="Severity.Error">Rejected</MudAlert>
+                            break;
+                        case TableRegistrationRecord.RegistrationStateEnum.Published:
+                            <MudAlert Severity="Severity.Success">Published</MudAlert>
+                            break;
+                    }
+                </MudItem>
+            </MudGrid>
+        </MudContainer>
+    </DialogContent>
+</MudDialog>
+
+@code {
+
+    [Parameter] public TableRegistrationRecord Record { get; set; }
+
+    /// <summary>
+    /// Attempt to change the status of a table registration
+    /// </summary>
+    /// <param name="registrationRecord"></param>
+    /// <param name="reject"></param>
+    private async void TryChangeRegistrationStatus(TableRegistrationRecord registrationRecord, bool reject)
+    {
+        DialogParameters<ConfirmDialog> dialog = new()
+        {
+            { x => x.ContentText, $"Are you sure, that you want to {(reject ? "Reject" : "Approve")} this application" },
+            { x => x.ActionButtonText, "Confirm" }
+        };
+        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
+        IDialogReference dialogRef = await DialogService.ShowAsync<ConfirmDialog>("Confirm", dialog, options);
+        DialogResult result = await dialogRef.Result;
+
+        if (!result.Canceled)
+        {
+            await TableRegService.PutTableRegistrationStatusAsync(registrationRecord, reject ? TableRegistrationRecord.RegistrationStateEnum.Rejected : TableRegistrationRecord.RegistrationStateEnum.Accepted);
+
+            Snackbar.Add($"Application was {(reject ? "Rejected" : "Approved")}");
+        }
+    }
+
+}

--- a/src/Eurofurence.App.Backoffice/Components/ArtistAlleyApplicationDialog.razor
+++ b/src/Eurofurence.App.Backoffice/Components/ArtistAlleyApplicationDialog.razor
@@ -33,6 +33,12 @@
                             <MudAlert Severity="Severity.Info">Pending</MudAlert>
                             <MudButton StartIcon="@Icons.Material.Filled.CheckCircle" @onclick="() => TryChangeRegistrationStatus(Record, false)">Approve</MudButton>
                             <MudButton StartIcon="@Icons.Material.Filled.Cancel" @onclick="() => TryChangeRegistrationStatus(Record, true)">Reject</MudButton>
+                            @*Show the delete button only for admins*@
+                            <AuthorizeView Roles="Admin">
+                                <Authorized>
+                                    <MudButton StartIcon="@Icons.Material.Filled.Delete" OnClick="args => DeleteRegistration()">Delete</MudButton>
+                                </Authorized>
+                            </AuthorizeView>
                             break;
                         case TableRegistrationRecord.RegistrationStateEnum.Accepted:
                             <MudAlert Severity="Severity.Success">Accepted</MudAlert>
@@ -53,6 +59,25 @@
 @code {
 
     [Parameter] public TableRegistrationRecord Record { get; set; }
+
+
+    private async Task DeleteRegistration()
+    {
+        DialogParameters<ConfirmDialog> dialog = new()
+        {
+            { x => x.ContentText, $"Are you sure, that you want to delete this application" },
+            { x => x.ActionButtonText, "Confirm" }
+        };
+        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
+        IDialogReference dialogRef = await DialogService.ShowAsync<ConfirmDialog>("Confirm", dialog, options);
+        DialogResult result = await dialogRef.Result;
+
+        if (!result.Canceled)
+        {
+            await TableRegService.DeleteTableRegistrationAsync(Record);
+            Snackbar.Add("Application Deleted", Severity.Success);
+        }
+    }
 
     /// <summary>
     /// Attempt to change the status of a table registration

--- a/src/Eurofurence.App.Backoffice/Components/ArtistAlleyApplicationDialog.razor
+++ b/src/Eurofurence.App.Backoffice/Components/ArtistAlleyApplicationDialog.razor
@@ -65,7 +65,7 @@
     {
         DialogParameters<ConfirmDialog> dialog = new()
         {
-            { x => x.ContentText, $"Are you sure, that you want to delete this application" },
+            { x => x.ContentText, $"Are you sure you want to delete this application?" },
             { x => x.ActionButtonText, "Confirm" }
         };
         var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
@@ -88,7 +88,7 @@
     {
         DialogParameters<ConfirmDialog> dialog = new()
         {
-            { x => x.ContentText, $"Are you sure, that you want to {(reject ? "Reject" : "Approve")} this application" },
+            { x => x.ContentText, $"Are you sure you want to {(reject ? "reject" : "approve")} this application?m" },
             { x => x.ActionButtonText, "Confirm" }
         };
         var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
@@ -99,8 +99,7 @@
         {
             await TableRegService.PutTableRegistrationStatusAsync(registrationRecord, reject ? TableRegistrationRecord.RegistrationStateEnum.Rejected : TableRegistrationRecord.RegistrationStateEnum.Accepted);
 
-            Snackbar.Add($"Application was {(reject ? "Rejected" : "Approved")}");
+            Snackbar.Add($"Application was {(reject ? "rejected" : "approved")}.");
         }
     }
-
 }

--- a/src/Eurofurence.App.Backoffice/Components/ArtistAlleyApplicationDialog.razor
+++ b/src/Eurofurence.App.Backoffice/Components/ArtistAlleyApplicationDialog.razor
@@ -9,15 +9,14 @@
     <DialogContent>
         <MudContainer Class="overflow-scroll pr-4">
             <MudGrid>
-                <MudItem>
-                    <MudImage ObjectFit="ObjectFit.Contain" Height="500" Width="500" Class="ml-2" Src="@Record.Image.Url">
-                        @if (string.IsNullOrEmpty(@Record.Image.Url))
-                        {
-                            <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
-                        }
-                    </MudImage>
-                </MudItem>
-
+                @if (Record.Image != null && !string.IsNullOrEmpty(Record.Image.Url))
+                {
+                    <MudItem xs="6">
+                        <MudLink Href="@Record.Image.Url">
+                            <MudImage ObjectFit="ObjectFit.Contain" Height="500" Width="500" Class="ml-2" Src="@Record.Image.Url"/>
+                        </MudLink>
+                    </MudItem>
+                }
                 <MudItem xs="6">
                     <MudTextField ReadOnly="true" Value="Record.Id" Label="ID"/>
                     <MudTextField ReadOnly="true" Value="Record.CreatedDateTimeUtc" Label="Application submitted at"/>
@@ -26,7 +25,7 @@
                     <MudTextField ReadOnly="true" Value="Record.WebsiteUrl" Label="Applicants Website"/>
                     <MudTextField ReadOnly="true" AutoGrow Value="Record.ShortDescription" Label="Short Description"/>
                     <MudTextField ReadOnly="true" Value="Record.TelegramHandle" Label="Applicant's Telegram handle"/>
-                    <MudTextField ReadOnly="true" Value="Record.Location" Label="Location"/>
+                    <MudTextField ReadOnly="true" Value="Record.Location" Label="Location" Class="mb-4"/>
                     @switch (Record.State)
                     {
                         case TableRegistrationRecord.RegistrationStateEnum.Pending:
@@ -88,7 +87,7 @@
     {
         DialogParameters<ConfirmDialog> dialog = new()
         {
-            { x => x.ContentText, $"Are you sure you want to {(reject ? "reject" : "approve")} this application?m" },
+            { x => x.ContentText, $"Are you sure you want to {(reject ? "reject" : "approve")} this application?" },
             { x => x.ActionButtonText, "Confirm" }
         };
         var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
@@ -97,9 +96,15 @@
 
         if (!result.Canceled)
         {
-            await TableRegService.PutTableRegistrationStatusAsync(registrationRecord, reject ? TableRegistrationRecord.RegistrationStateEnum.Rejected : TableRegistrationRecord.RegistrationStateEnum.Accepted);
+            var state = reject ? TableRegistrationRecord.RegistrationStateEnum.Rejected : TableRegistrationRecord.RegistrationStateEnum.Accepted;
+            await TableRegService.PutTableRegistrationStatusAsync(registrationRecord, state);
 
             Snackbar.Add($"Application was {(reject ? "rejected" : "approved")}.");
+
+            Record.State = state;
+
+            StateHasChanged();
         }
     }
+
 }

--- a/src/Eurofurence.App.Backoffice/Components/ConfirmDialog.razor
+++ b/src/Eurofurence.App.Backoffice/Components/ConfirmDialog.razor
@@ -1,0 +1,28 @@
+<MudDialog>
+    <DialogContent>
+        <MudText>@ContentText</MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton @onclick="OnClickCancle">Cancel</MudButton>
+        <MudButton Color="@ConfirmButtonColor" @onclick="OnClickConfirm">@ActionButtonText</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private MudDialogInstance MudDialog { get; set; }
+
+    /// <summary>
+    /// Represents the text that should be shown
+    /// </summary>
+    [Parameter]
+    public string ContentText { get; set; }
+
+    [Parameter] public string ActionButtonText { get; set; } = "Confirm";
+
+    [Parameter] public Color ConfirmButtonColor { get; set; } = Color.Info;
+
+    private void OnClickCancle() => MudDialog.Cancel();
+
+    private void OnClickConfirm() => MudDialog.Close();
+
+}

--- a/src/Eurofurence.App.Backoffice/Layout/MainLayout.razor
+++ b/src/Eurofurence.App.Backoffice/Layout/MainLayout.razor
@@ -18,7 +18,7 @@
         <NavMenu/>
     </MudDrawer>
     <MudMainContent>
-        <MudContainer Class="mt-4">
+        <MudContainer Fixed="true" Class="mt-4">
             @Body
         </MudContainer>
     </MudMainContent>

--- a/src/Eurofurence.App.Backoffice/Layout/NavMenu.razor
+++ b/src/Eurofurence.App.Backoffice/Layout/NavMenu.razor
@@ -5,4 +5,7 @@
         </MudNavLink>
         <MudNavLink Href="images" Icon="@Icons.Material.Outlined.Image" Match="NavLinkMatch.Prefix">Images</MudNavLink>
     </AuthorizeView>
+    <AuthorizeView Roles="ArtistAlleyModerator">
+        <MudNavLink Href="artistAlleyModeration" Icon="@Icons.Material.Outlined.AddModerator">Artist Alley Moderation</MudNavLink>
+    </AuthorizeView>
 </MudNavMenu>

--- a/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
@@ -27,14 +27,35 @@ More data of the applicant shall be visble an extra dialog TODO: Needs to be don
 <MudDataGrid T="TableRegistrationRecord" @ref="_dataGrid" ServerData="@GetRegistrations" FilterMode="@_filterMode">
     <ToolBarContent>
         <MudTextField @bind-Value="_imageSearch" Placeholder="Search" Adornment="Adornment.Start" Immediate="true"
-                      AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
+                      AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0">
+        </MudTextField>
     </ToolBarContent>
     <Columns>
+        <TemplateColumn Title="Preview" CellClass="d-flex justify-center">
+            <CellTemplate>
+                @if (!string.IsNullOrEmpty(@context.Item.Image.Url))
+                {
+                    <MudLink Href="@context.Item.Image.Url">
+                        <MudImage Class="ml-2" Width="100" Height="100" ObjectFit="ObjectFit.Contain"
+                                  Src="@context.Item.Image.Url"/>
+                    </MudLink>
+                }
+                else
+                {
+                    <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
+                }
+            </CellTemplate>
+        </TemplateColumn>
         <PropertyColumn Title="Applicant's Username" Property="arg => arg.OwnerUsername"/>
         <PropertyColumn Title="Applicant's Name" Property="arg => arg.DisplayName"/>
         <PropertyColumn Title="Applicant's Location" Property="arg => arg.Location"/>
         <PropertyColumn Title="Applicant's Descriptions" Property="arg => arg.ShortDescription"/>
         <PropertyColumn Property="arg => arg.DisplayName"/>
+        <TemplateColumn>
+            <CellTemplate>
+                <MudButton OnClick="() => OpenMore(context.Item)">More</MudButton>
+            </CellTemplate>
+        </TemplateColumn>
         <TemplateColumn Title="Status" SortBy="@(x => x.State)" Sortable="true" Filterable="true">
             <CellTemplate>
                 @switch (context.Item.State)
@@ -50,6 +71,7 @@ More data of the applicant shall be visble an extra dialog TODO: Needs to be don
                         <MudAlert Severity="Severity.Error">Rejected</MudAlert>
                         break;
                     case TableRegistrationRecord.RegistrationStateEnum.Published:
+                        <MudAlert Severity="Severity.Success">Published</MudAlert>
                         break;
                 }
 
@@ -57,17 +79,21 @@ More data of the applicant shall be visble an extra dialog TODO: Needs to be don
         </TemplateColumn>
     </Columns>
     <PagerContent>
-        <MudDataGridPager T="TableRegistrationRecord" />
+        <MudDataGridPager T="TableRegistrationRecord"/>
     </PagerContent>
 </MudDataGrid>
 
 @code {
+
+    #region Attributes
+
     private MudDataGrid<TableRegistrationRecord>? _dataGrid;
 
     private string? _imageSearch;
 
     private DataGridFilterMode _filterMode = DataGridFilterMode.Simple;
 
+    #endregion
 
     /// <summary>
     /// Attempt to change the status of a table registration
@@ -87,10 +113,25 @@ More data of the applicant shall be visble an extra dialog TODO: Needs to be don
 
         if (!result.Canceled)
         {
-            TableRegService.PutTableRegistrationStatusAsync(registrationRecord, reject ? TableRegistrationRecord.RegistrationStateEnum.Rejected : TableRegistrationRecord.RegistrationStateEnum.Accepted);
+            await TableRegService.PutTableRegistrationStatusAsync(registrationRecord, reject ? TableRegistrationRecord.RegistrationStateEnum.Rejected : TableRegistrationRecord.RegistrationStateEnum.Accepted);
+            await _dataGrid.ReloadServerData();
             Snackbar.Add($"Application was {(reject ? "Rejected" : "Approved")}");
         }
     }
+
+
+    private async Task OpenMore(TableRegistrationRecord contextItem)
+    {
+        var dialog = new DialogParameters<ArtistAlleyApplicationDialog>()
+        {
+            { x => x.Record, contextItem }
+        };
+
+        var options = new DialogOptions { MaxWidth = MaxWidth.Large, FullWidth = true,CloseButton = true};
+
+        DialogService.ShowAsync<ArtistAlleyApplicationDialog>("Application Details", dialog, options);
+    }
+
 
     /// <summary>
     /// Filter
@@ -101,6 +142,11 @@ More data of the applicant shall be visble an extra dialog TODO: Needs to be don
         string.IsNullOrEmpty(_imageSearch) ? entries : entries.Where(x => x.DisplayName.Contains(_imageSearch, StringComparison.OrdinalIgnoreCase));
 
 
+    /// <summary>
+    /// Requests the table registrations from <see cref="IArtistAlleyService"/>
+    /// </summary>
+    /// <param name="gridState"></param>
+    /// <returns></returns>
     private async Task<GridData<TableRegistrationRecord>> GetRegistrations(GridState<TableRegistrationRecord> gridState)
     {
         IEnumerable<TableRegistrationRecord> registrations = await TableRegService.GetTableRegistrationsAsync();
@@ -124,7 +170,7 @@ More data of the applicant shall be visble an extra dialog TODO: Needs to be don
     {
         _imageSearch = searchString;
         _dataGrid.ReloadServerData();
-
     }
+
 
 }

--- a/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
@@ -22,7 +22,7 @@
 @*
 Table showing the basic informations for each application.
 
-More data of the applicant shall be visble an extra dialog TODO: Needs to be done
+More data of the applicant shall be visble an extra dialog
  *@
 <MudDataGrid T="TableRegistrationRecord" @ref="_dataGrid" ServerData="@GetRegistrations" FilterMode="@_filterMode">
     <ToolBarContent>
@@ -33,7 +33,7 @@ More data of the applicant shall be visble an extra dialog TODO: Needs to be don
     <Columns>
         <TemplateColumn Title="Preview" CellClass="d-flex justify-center">
             <CellTemplate>
-                @if (!string.IsNullOrEmpty(@context.Item.Image.Url))
+                @if (context.Item.Image != null &&  !string.IsNullOrEmpty(context.Item.Image.Url))
                 {
                     <MudLink Href="@context.Item.Image.Url">
                         <MudImage Class="ml-2" Width="100" Height="100" ObjectFit="ObjectFit.Contain"
@@ -53,16 +53,22 @@ More data of the applicant shall be visble an extra dialog TODO: Needs to be don
         <PropertyColumn Property="arg => arg.DisplayName"/>
         <TemplateColumn>
             <CellTemplate>
-                <MudButton OnClick="() => OpenMore(context.Item)">More</MudButton>
+                <MudButton OnClick="() => OpenMoreDialog(context.Item)">More</MudButton>
             </CellTemplate>
         </TemplateColumn>
-        <TemplateColumn Title="Status" SortBy="@(x => x.State)" Sortable="true" Filterable="true">
-            <CellTemplate>
-                @switch (context.Item.State)
+        <TemplateColumn Title="Status" Context="context2" SortBy="@(x => x.State)" Sortable="true" Filterable="true">
+            <CellTemplate >
+                @switch (context2.Item.State)
                 {
                     case TableRegistrationRecord.RegistrationStateEnum.Pending:
-                        <MudButton StartIcon="@Icons.Material.Filled.CheckCircle" @onclick="() => TryChangeRegistrationStatus(context.Item, false)">Approve</MudButton>
-                        <MudButton StartIcon="@Icons.Material.Filled.Cancel" @onclick="() => TryChangeRegistrationStatus(context.Item, true)">Reject</MudButton>
+                        <MudButton StartIcon="@Icons.Material.Filled.CheckCircle" Context="bttn" ref="appBtn"OnClick="args => TryChangeRegistrationStatus(context2.Item, false)">Approve</MudButton>
+                        <MudButton StartIcon="@Icons.Material.Filled.Cancel" OnClick="args => TryChangeRegistrationStatus(context2.Item, true)">Reject</MudButton>
+                        @*Show the delete button only for admins*@
+                        <AuthorizeView Roles="Admin">
+                            <Authorized>
+                                <MudButton StartIcon="@Icons.Material.Filled.Delete" OnClick="args => DeleteRegistration(context2.Item)">Delete</MudButton>
+                            </Authorized>
+                        </AuthorizeView>
                         break;
                     case TableRegistrationRecord.RegistrationStateEnum.Accepted:
                         <MudAlert Severity="Severity.Success">Accepted</MudAlert>
@@ -93,13 +99,36 @@ More data of the applicant shall be visble an extra dialog TODO: Needs to be don
 
     private DataGridFilterMode _filterMode = DataGridFilterMode.Simple;
 
+    private Dictionary<TableRegistrationRecord, bool> RecordToOperationState = new();
+
     #endregion
+
+    #region Methods
+
+    private async Task DeleteRegistration(TableRegistrationRecord registrationRecord)
+    {
+        DialogParameters<ConfirmDialog> dialog = new()
+        {
+            { x => x.ContentText, $"Are you sure, that you want to delete this application" },
+            { x => x.ActionButtonText, "Confirm" }
+        };
+        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
+        IDialogReference dialogRef = await DialogService.ShowAsync<ConfirmDialog>("Confirm", dialog, options);
+        DialogResult result = await dialogRef.Result;
+
+        if (!result.Canceled)
+        {
+            await TableRegService.DeleteTableRegistrationAsync(registrationRecord);
+            await _dataGrid.ReloadServerData();
+            Snackbar.Add("Application Deleted", Severity.Success);
+        }
+    }
 
     /// <summary>
     /// Attempt to change the status of a table registration
     /// </summary>
     /// <param name="registrationRecord"></param>
-    /// <param name="reject"></param>
+    /// <param name="reject">True if the application should be rejected and false if it should be accepted</param>
     private async void TryChangeRegistrationStatus(TableRegistrationRecord registrationRecord, bool reject)
     {
         DialogParameters<ConfirmDialog> dialog = new()
@@ -115,19 +144,22 @@ More data of the applicant shall be visble an extra dialog TODO: Needs to be don
         {
             await TableRegService.PutTableRegistrationStatusAsync(registrationRecord, reject ? TableRegistrationRecord.RegistrationStateEnum.Rejected : TableRegistrationRecord.RegistrationStateEnum.Accepted);
             await _dataGrid.ReloadServerData();
-            Snackbar.Add($"Application was {(reject ? "Rejected" : "Approved")}");
+            Snackbar.Add($"Application was {(reject ? "Rejected" : "Approved")}", Severity.Success);
         }
     }
 
-
-    private async Task OpenMore(TableRegistrationRecord contextItem)
+    /// <summary>
+    /// Opens a dialog
+    /// </summary>
+    /// <param name="contextItem"></param>
+    private async Task OpenMoreDialog(TableRegistrationRecord contextItem)
     {
         var dialog = new DialogParameters<ArtistAlleyApplicationDialog>()
         {
             { x => x.Record, contextItem }
         };
 
-        var options = new DialogOptions { MaxWidth = MaxWidth.Large, FullWidth = true,CloseButton = true};
+        var options = new DialogOptions { MaxWidth = MaxWidth.Large, FullWidth = true, CloseButton = true };
 
         DialogService.ShowAsync<ArtistAlleyApplicationDialog>("Application Details", dialog, options);
     }
@@ -172,5 +204,6 @@ More data of the applicant shall be visble an extra dialog TODO: Needs to be don
         _dataGrid.ReloadServerData();
     }
 
+    #endregion
 
 }

--- a/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
@@ -35,10 +35,6 @@ More data of the applicant shall be visble an extra dialog
                                   Src="@context.Item.Image.Url"/>
                     </MudLink>
                 }
-                else
-                {
-                    <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
-                }
             </CellTemplate>
         </TemplateColumn>
         <PropertyColumn Title="Applicant's Username" Property="arg => arg.OwnerUsername" Filterable="false"/>
@@ -49,30 +45,37 @@ More data of the applicant shall be visble an extra dialog
         </PropertyColumn>
         <TemplateColumn Context="context2">
             <CellTemplate>
-                @switch (context2.Item.State)
-                {
-                    case TableRegistrationRecord.RegistrationStateEnum.Pending:
-                        <MudButton StartIcon="@Icons.Material.Filled.CheckCircle" Context="bttn" ref="appBtn"OnClick="args => TryChangeRegistrationStatus(context2.Item, false)">Approve</MudButton>
-                        <MudButton StartIcon="@Icons.Material.Filled.Cancel" OnClick="args => TryChangeRegistrationStatus(context2.Item, true)">Reject</MudButton>
-                        @*Show the delete button only for admins*@
-                        <AuthorizeView Roles="Admin">
-                            <Authorized>
-                                <MudButton StartIcon="@Icons.Material.Filled.Delete" OnClick="args => DeleteRegistration(context2.Item)">Delete</MudButton>
-                            </Authorized>
-                        </AuthorizeView>
-                        <MudButton StartIcon="@Icons.Material.Filled.Menu" OnClick="() => OpenMoreDialog(context2.Item)">More...</MudButton>
-                        break;
-                    case TableRegistrationRecord.RegistrationStateEnum.Accepted:
-                        <MudAlert Severity="Severity.Success">Accepted</MudAlert>
-                        break;
-                    case TableRegistrationRecord.RegistrationStateEnum.Rejected:
-                        <MudAlert Severity="Severity.Error">Rejected</MudAlert>
-                        break;
-                    case TableRegistrationRecord.RegistrationStateEnum.Published:
-                        <MudAlert Severity="Severity.Success">Published</MudAlert>
-                        break;
-                }
-
+                <MudContainer MaxWidth="MaxWidth.Small">
+                    <MudGrid>
+                        <MudItem xs="10">
+                            @switch (context2.Item?.State)
+                            {
+                                case TableRegistrationRecord.RegistrationStateEnum.Pending:
+                                    <MudButton StartIcon="@Icons.Material.Filled.CheckCircle" Context="bttn" ref="appBtn"OnClick="args => TryChangeRegistrationStatus(context2.Item, false)">Approve</MudButton>
+                                    <MudButton StartIcon="@Icons.Material.Filled.Cancel" OnClick="args => TryChangeRegistrationStatus(context2.Item, true)">Reject</MudButton>
+                                    @*Show the delete button only for admins*@
+                                    <AuthorizeView Roles="Admin">
+                                        <Authorized>
+                                            <MudButton StartIcon="@Icons.Material.Filled.Delete" OnClick="args => DeleteRegistration(context2.Item)">Delete</MudButton>
+                                        </Authorized>
+                                    </AuthorizeView>
+                                    break;
+                                case TableRegistrationRecord.RegistrationStateEnum.Accepted:
+                                    <MudAlert Severity="Severity.Success">Accepted</MudAlert>
+                                    break;
+                                case TableRegistrationRecord.RegistrationStateEnum.Rejected:
+                                    <MudAlert Severity="Severity.Error">Rejected</MudAlert>
+                                    break;
+                                case TableRegistrationRecord.RegistrationStateEnum.Published:
+                                    <MudAlert Severity="Severity.Success">Published</MudAlert>
+                                    break;
+                            }
+                        </MudItem>
+                        <MudItem xs="2">
+                            <MudButton StartIcon="@Icons.Material.Filled.Menu" OnClick="() => OpenMoreDialog(context2.Item)">More...</MudButton>
+                        </MudItem>
+                    </MudGrid>
+                </MudContainer>
             </CellTemplate>
         </TemplateColumn>
     </Columns>
@@ -94,7 +97,7 @@ More data of the applicant shall be visble an extra dialog
 
     protected override async Task OnInitializedAsync()
     {
-        _items = await GetRegistrations();
+        _items = await GetRegistrationsAsync();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -145,7 +148,8 @@ More data of the applicant shall be visble an extra dialog
         if (!result.Canceled)
         {
             await TableRegService.PutTableRegistrationStatusAsync(registrationRecord, reject ? TableRegistrationRecord.RegistrationStateEnum.Rejected : TableRegistrationRecord.RegistrationStateEnum.Accepted);
-            await _dataGrid.ReloadServerData();
+            _items = await GetRegistrationsAsync();
+            StateHasChanged();
             Snackbar.Add($"Application was {(reject ? "rejected" : "approved")}.", Severity.Success);
         }
     }
@@ -156,14 +160,19 @@ More data of the applicant shall be visble an extra dialog
     /// <param name="contextItem"></param>
     private async Task OpenMoreDialog(TableRegistrationRecord contextItem)
     {
-        var dialog = new DialogParameters<ArtistAlleyApplicationDialog>()
+        var parameters = new DialogParameters<ArtistAlleyApplicationDialog>()
         {
             { x => x.Record, contextItem }
         };
 
         var options = new DialogOptions { MaxWidth = MaxWidth.Large, FullWidth = true, CloseButton = true };
 
-        await DialogService.ShowAsync<ArtistAlleyApplicationDialog>("Application Details", dialog, options);
+        var dialog = await DialogService.ShowAsync<ArtistAlleyApplicationDialog>("Application Details", parameters, options);
+
+        await dialog.Result;
+
+        _items = await GetRegistrationsAsync();
+        StateHasChanged();
     }
 
 
@@ -183,7 +192,7 @@ More data of the applicant shall be visble an extra dialog
     /// Requests the table registrations from <see cref="IArtistAlleyService"/>
     /// </summary>
     /// <returns></returns>
-    private async Task<IEnumerable<TableRegistrationRecord>> GetRegistrations()
+    private async Task<IEnumerable<TableRegistrationRecord>> GetRegistrationsAsync()
     {
         IEnumerable<TableRegistrationRecord> registrations = await TableRegService.GetTableRegistrationsAsync();
 
@@ -202,7 +211,7 @@ More data of the applicant shall be visble an extra dialog
     private async void Search(string searchString)
     {
         _search = searchString;
-        _items = await GetRegistrations();
+        _items = await GetRegistrationsAsync();
     }
 
     #endregion

--- a/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
@@ -109,7 +109,7 @@ More data of the applicant shall be visble an extra dialog
     {
         DialogParameters<ConfirmDialog> dialog = new()
         {
-            { x => x.ContentText, $"Are you sure, that you want to delete this application" },
+            { x => x.ContentText, $"Are you sure you want to delete this application?" },
             { x => x.ActionButtonText, "Confirm" }
         };
         var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
@@ -133,7 +133,7 @@ More data of the applicant shall be visble an extra dialog
     {
         DialogParameters<ConfirmDialog> dialog = new()
         {
-            { x => x.ContentText, $"Are you sure, that you want to {(reject ? "Reject" : "Approve")} this application" },
+            { x => x.ContentText, $"Are you sure you want to {(reject ? "reject" : "approve")} this application?" },
             { x => x.ActionButtonText, "Confirm" }
         };
         var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
@@ -144,7 +144,7 @@ More data of the applicant shall be visble an extra dialog
         {
             await TableRegService.PutTableRegistrationStatusAsync(registrationRecord, reject ? TableRegistrationRecord.RegistrationStateEnum.Rejected : TableRegistrationRecord.RegistrationStateEnum.Accepted);
             await _dataGrid.ReloadServerData();
-            Snackbar.Add($"Application was {(reject ? "Rejected" : "Approved")}", Severity.Success);
+            Snackbar.Add($"Application was {(reject ? "rejected" : "approved")}.", Severity.Success);
         }
     }
 

--- a/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
@@ -24,12 +24,7 @@ Table showing the basic informations for each application.
 
 More data of the applicant shall be visble an extra dialog
  *@
-<MudDataGrid T="TableRegistrationRecord" @ref="_dataGrid" ServerData="@GetRegistrations" FilterMode="@_filterMode">
-    <ToolBarContent>
-        <MudTextField @bind-Value="_imageSearch" Placeholder="Search" Adornment="Adornment.Start" Immediate="true"
-                      AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0">
-        </MudTextField>
-    </ToolBarContent>
+<MudDataGrid T="TableRegistrationRecord" @ref="_dataGrid" Items="_items" Filterable="true" FilterMode="@DataGridFilterMode.ColumnFilterMenu">
     <Columns>
         <TemplateColumn Title="Preview" CellClass="d-flex justify-center">
             <CellTemplate>
@@ -46,18 +41,14 @@ More data of the applicant shall be visble an extra dialog
                 }
             </CellTemplate>
         </TemplateColumn>
-        <PropertyColumn Title="Applicant's Username" Property="arg => arg.OwnerUsername"/>
-        <PropertyColumn Title="Applicant's Name" Property="arg => arg.DisplayName"/>
-        <PropertyColumn Title="Applicant's Location" Property="arg => arg.Location"/>
-        <PropertyColumn Title="Applicant's Descriptions" Property="arg => arg.ShortDescription"/>
-        <PropertyColumn Property="arg => arg.DisplayName"/>
-        <TemplateColumn>
+        <PropertyColumn Title="Applicant's Username" Property="arg => arg.OwnerUsername" Filterable="false"/>
+        <PropertyColumn Title="Applicant's Name" Property="arg => arg.DisplayName" Filterable="false" />
+        <PropertyColumn Title="Applicant's Location" Property="arg => arg.Location" Filterable="false" />
+        <PropertyColumn Title="Applicant's Descriptions" Property="arg => arg.ShortDescription" Filterable="false" />
+        <PropertyColumn Title="Status" Property="arg => arg.State" Filterable="true">
+        </PropertyColumn>
+        <TemplateColumn Context="context2">
             <CellTemplate>
-                <MudButton OnClick="() => OpenMoreDialog(context.Item)">More</MudButton>
-            </CellTemplate>
-        </TemplateColumn>
-        <TemplateColumn Title="Status" Context="context2" SortBy="@(x => x.State)" Sortable="true" Filterable="true">
-            <CellTemplate >
                 @switch (context2.Item.State)
                 {
                     case TableRegistrationRecord.RegistrationStateEnum.Pending:
@@ -69,6 +60,7 @@ More data of the applicant shall be visble an extra dialog
                                 <MudButton StartIcon="@Icons.Material.Filled.Delete" OnClick="args => DeleteRegistration(context2.Item)">Delete</MudButton>
                             </Authorized>
                         </AuthorizeView>
+                        <MudButton StartIcon="@Icons.Material.Filled.Menu" OnClick="() => OpenMoreDialog(context2.Item)">More...</MudButton>
                         break;
                     case TableRegistrationRecord.RegistrationStateEnum.Accepted:
                         <MudAlert Severity="Severity.Success">Accepted</MudAlert>
@@ -94,17 +86,27 @@ More data of the applicant shall be visble an extra dialog
     #region Attributes
 
     private MudDataGrid<TableRegistrationRecord>? _dataGrid;
-
-    private string? _imageSearch;
-
-    private DataGridFilterMode _filterMode = DataGridFilterMode.Simple;
-
-    private Dictionary<TableRegistrationRecord, bool> RecordToOperationState = new();
-
+    private IEnumerable<TableRegistrationRecord> _items = new List<TableRegistrationRecord>();
+    private string? _search;
     #endregion
 
     #region Methods
 
+    protected override async Task OnInitializedAsync()
+    {
+        _items = await GetRegistrations();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (firstRender)
+        {
+            _dataGrid?.SetSortAsync(nameof(TableRegistrationRecord.State), SortDirection.Ascending, x => x.State);
+        }
+    }
+    
     private async Task DeleteRegistration(TableRegistrationRecord registrationRecord)
     {
         DialogParameters<ConfirmDialog> dialog = new()
@@ -161,7 +163,7 @@ More data of the applicant shall be visble an extra dialog
 
         var options = new DialogOptions { MaxWidth = MaxWidth.Large, FullWidth = true, CloseButton = true };
 
-        DialogService.ShowAsync<ArtistAlleyApplicationDialog>("Application Details", dialog, options);
+        await DialogService.ShowAsync<ArtistAlleyApplicationDialog>("Application Details", dialog, options);
     }
 
 
@@ -171,15 +173,17 @@ More data of the applicant shall be visble an extra dialog
     /// <param name="entries"></param>
     /// <returns></returns>
     private IEnumerable<TableRegistrationRecord> Filter(IEnumerable<TableRegistrationRecord> entries) =>
-        string.IsNullOrEmpty(_imageSearch) ? entries : entries.Where(x => x.DisplayName.Contains(_imageSearch, StringComparison.OrdinalIgnoreCase));
+        string.IsNullOrEmpty(_search) ? entries : entries.Where(x => x.DisplayName.Contains(_search, StringComparison.OrdinalIgnoreCase)
+            || x.OwnerUsername.Contains(_search, StringComparison.OrdinalIgnoreCase)
+            || x.Location.Contains(_search, StringComparison.OrdinalIgnoreCase)
+            || x.ShortDescription.Contains(_search, StringComparison.OrdinalIgnoreCase));
 
 
     /// <summary>
     /// Requests the table registrations from <see cref="IArtistAlleyService"/>
     /// </summary>
-    /// <param name="gridState"></param>
     /// <returns></returns>
-    private async Task<GridData<TableRegistrationRecord>> GetRegistrations(GridState<TableRegistrationRecord> gridState)
+    private async Task<IEnumerable<TableRegistrationRecord>> GetRegistrations()
     {
         IEnumerable<TableRegistrationRecord> registrations = await TableRegService.GetTableRegistrationsAsync();
 
@@ -192,16 +196,13 @@ More data of the applicant shall be visble an extra dialog
 
         registrations = Filter(registrations);
 
-        GridData<TableRegistrationRecord> result = new();
-        result.Items = registrations;
-        //result.TotalItems = registrations.Count;
-        return result;
+        return registrations;
     }
 
-    private void Search(string searchString)
+    private async void Search(string searchString)
     {
-        _imageSearch = searchString;
-        _dataGrid.ReloadServerData();
+        _search = searchString;
+        _items = await GetRegistrations();
     }
 
     #endregion

--- a/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
@@ -1,0 +1,108 @@
+@page "/artistAlleyModeration"
+@using Eurofurence.App.Backoffice.Components
+@using Eurofurence.App.Backoffice.Services
+@using Eurofurence.App.Domain.Model.ArtistsAlley
+@using Microsoft.AspNetCore.Authorization
+@using Color = MudBlazor.Color
+
+@attribute [Authorize(Roles = "ArtistAlleyModerator")]
+
+@inject IArtistAlleyService TableRegService
+@inject IDialogService DialogService
+@inject ISnackbar Snackbar
+
+
+<MudToolBar>
+    <MudText Typo="Typo.h6">Artist Alley Moderation</MudText>
+    <MudSpacer/>
+    <MudSpacer/>
+    <MudTextField T="string" ValueChanged="Search" Label="Search" Variant="Variant.Outlined" Margin="Margin.Dense"
+                  Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Secondary"/>
+</MudToolBar>
+@*
+Table showing the basic informations for each application.
+
+More data of the applicant shall be visble an extra dialog TODO: Needs to be done
+ *@
+<MudDataGrid T="TableRegistrationRecord" ServerData="@GetRegistrations" FilterMode="@_filterMode">
+    <Columns>
+        <PropertyColumn Title="Applicant's Username" Property="arg => arg.OwnerUsername"/>
+        <PropertyColumn Title="Applicant's Name" Property="arg => arg.DisplayName"/>
+        <PropertyColumn Title="Applicant's Location" Property="arg => arg.Location"/>
+        <PropertyColumn Title="Applicant's Descriptions" Property="arg => arg.ShortDescription"/>
+        <PropertyColumn Property="arg => arg.DisplayName"/>
+        <TemplateColumn Title="Status" SortBy="@(x => x.State)" Sortable="true" Filterable="true">
+            <CellTemplate>
+                @switch (context.Item.State)
+                {
+                    case TableRegistrationRecord.RegistrationStateEnum.Pending:
+                        <MudButton StartIcon="@Icons.Material.Filled.CheckCircle" @onclick="() => TryChangeRegistrationStatus(context.Item, false)">Approve</MudButton>
+                        <MudButton StartIcon="@Icons.Material.Filled.Cancel" @onclick="() => TryChangeRegistrationStatus(context.Item, true)">Reject</MudButton>
+                        break;
+                    case TableRegistrationRecord.RegistrationStateEnum.Accepted:
+                        <MudAlert Severity="Severity.Success">Accepted</MudAlert>
+                        break;
+                    case TableRegistrationRecord.RegistrationStateEnum.Rejected:
+                        <MudAlert Severity="Severity.Error">Rejected</MudAlert>
+                        break;
+                    case TableRegistrationRecord.RegistrationStateEnum.Published:
+                        break;
+                }
+
+            </CellTemplate>
+        </TemplateColumn>
+    </Columns>
+</MudDataGrid>
+
+@code {
+
+    private string? _imageSearch;
+
+    private DataGridFilterMode _filterMode = DataGridFilterMode.Simple;
+
+    /// <summary>
+    /// Attempt to change the status of a table registration
+    /// </summary>
+    /// <param name="registrationRecord"></param>
+    /// <param name="reject"></param>
+    private async void TryChangeRegistrationStatus(TableRegistrationRecord registrationRecord, bool reject)
+    {
+        DialogParameters<ConfirmDialog> dialog = new()
+        {
+            { x => x.ContentText, $"Are you sure, that you want to {(reject ? "Reject" : "Approve")} this application" },
+            { x => x.ActionButtonText, "Confirm" }
+        };
+        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
+        IDialogReference dialogRef = await DialogService.ShowAsync<ConfirmDialog>("Confirm", dialog, options);
+        DialogResult result = await dialogRef.Result;
+
+        if (!result.Canceled)
+        {
+            TableRegService.PutTableRegistrationStatusAsync(registrationRecord, reject ? TableRegistrationRecord.RegistrationStateEnum.Rejected : TableRegistrationRecord.RegistrationStateEnum.Accepted);
+            Snackbar.Add($"Application was {(reject ? "Rejected" : "Approved")}");
+        }
+    }
+
+
+    private async Task<GridData<TableRegistrationRecord>> GetRegistrations(GridState<TableRegistrationRecord> gridState)
+    {
+        IList<TableRegistrationRecord> registrations = await TableRegService.GetTableRegistrationsAsync();
+
+        // Show pending applications fist.
+        // Sorting may be changed by the user in the UI.
+        registrations = registrations
+            .Select(x => x)
+            .OrderBy(x => x.State)
+            .ToList();
+
+        GridData<TableRegistrationRecord> result = new();
+        result.Items = registrations;
+        result.TotalItems = registrations.Count;
+        return result;
+    }
+
+    private void Search(string searchString)
+    {
+        _imageSearch = searchString;
+    }
+}

--- a/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
@@ -124,7 +124,8 @@ More data of the applicant shall be visble an extra dialog
         if (!result.Canceled)
         {
             await TableRegService.DeleteTableRegistrationAsync(registrationRecord);
-            await _dataGrid.ReloadServerData();
+            _items = await GetRegistrationsAsync();
+            StateHasChanged();
             Snackbar.Add("Application Deleted", Severity.Success);
         }
     }

--- a/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
@@ -24,7 +24,11 @@ Table showing the basic informations for each application.
 
 More data of the applicant shall be visble an extra dialog TODO: Needs to be done
  *@
-<MudDataGrid T="TableRegistrationRecord" ServerData="@GetRegistrations" FilterMode="@_filterMode">
+<MudDataGrid T="TableRegistrationRecord" @ref="_dataGrid" ServerData="@GetRegistrations" FilterMode="@_filterMode">
+    <ToolBarContent>
+        <MudTextField @bind-Value="_imageSearch" Placeholder="Search" Adornment="Adornment.Start" Immediate="true"
+                      AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
+    </ToolBarContent>
     <Columns>
         <PropertyColumn Title="Applicant's Username" Property="arg => arg.OwnerUsername"/>
         <PropertyColumn Title="Applicant's Name" Property="arg => arg.DisplayName"/>
@@ -52,13 +56,18 @@ More data of the applicant shall be visble an extra dialog TODO: Needs to be don
             </CellTemplate>
         </TemplateColumn>
     </Columns>
+    <PagerContent>
+        <MudDataGridPager T="TableRegistrationRecord" />
+    </PagerContent>
 </MudDataGrid>
 
 @code {
+    private MudDataGrid<TableRegistrationRecord>? _dataGrid;
 
     private string? _imageSearch;
 
     private DataGridFilterMode _filterMode = DataGridFilterMode.Simple;
+
 
     /// <summary>
     /// Attempt to change the status of a table registration
@@ -83,10 +92,18 @@ More data of the applicant shall be visble an extra dialog TODO: Needs to be don
         }
     }
 
+    /// <summary>
+    /// Filter
+    /// </summary>
+    /// <param name="entries"></param>
+    /// <returns></returns>
+    private IEnumerable<TableRegistrationRecord> Filter(IEnumerable<TableRegistrationRecord> entries) =>
+        string.IsNullOrEmpty(_imageSearch) ? entries : entries.Where(x => x.DisplayName.Contains(_imageSearch, StringComparison.OrdinalIgnoreCase));
+
 
     private async Task<GridData<TableRegistrationRecord>> GetRegistrations(GridState<TableRegistrationRecord> gridState)
     {
-        IList<TableRegistrationRecord> registrations = await TableRegService.GetTableRegistrationsAsync();
+        IEnumerable<TableRegistrationRecord> registrations = await TableRegService.GetTableRegistrationsAsync();
 
         // Show pending applications fist.
         // Sorting may be changed by the user in the UI.
@@ -95,14 +112,19 @@ More data of the applicant shall be visble an extra dialog TODO: Needs to be don
             .OrderBy(x => x.State)
             .ToList();
 
+        registrations = Filter(registrations);
+
         GridData<TableRegistrationRecord> result = new();
         result.Items = registrations;
-        result.TotalItems = registrations.Count;
+        //result.TotalItems = registrations.Count;
         return result;
     }
 
     private void Search(string searchString)
     {
         _imageSearch = searchString;
+        _dataGrid.ReloadServerData();
+
     }
+
 }

--- a/src/Eurofurence.App.Backoffice/Pages/Images.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/Images.razor
@@ -176,16 +176,28 @@
 
     private async Task DeleteImage(Guid id)
     {
-        var result = await ImageService.DeleteImageAsync(id);
-        if (result)
+        DialogParameters<ConfirmDialog> dialog = new()
         {
-            Snackbar.Add("Image deleted.", Severity.Success);
-            await LoadImagesAsync();
-            _dataGrid?.ReloadServerData();
-        }
-        else
+            { x => x.ContentText, $"Are you sure you want to delete this ímage?" },
+            { x => x.ActionButtonText, "Confirm" }
+        };
+        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
+        IDialogReference dialogRef = await DialogService.ShowAsync<ConfirmDialog>("Confirm", dialog, options);
+        DialogResult dialogResult = await dialogRef.Result;
+
+        if (!dialogResult.Canceled)
         {
-            Snackbar.Add("Error deleting image.", Severity.Error);
+            var result = await ImageService.DeleteImageAsync(id);
+            if (result)
+            {
+                Snackbar.Add("Image deleted.", Severity.Success);
+                await LoadImagesAsync();
+                _dataGrid?.ReloadServerData();
+            }
+            else
+            {
+                Snackbar.Add("Error deleting image.", Severity.Error);
+            }
         }
     }
 

--- a/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
@@ -232,16 +232,28 @@
 
     private async Task DeleteKnowledgeEntry(Guid id)
     {
-        var result = await KnowledgeService.DeleteKnowledgeEntryAsync(id);
-        if (result)
+        DialogParameters<ConfirmDialog> dialog = new()
         {
-            Snackbar.Add("Knowledge entry deleted.", Severity.Success);
-        }
-        else
+            { x => x.ContentText, $"Are you sure you want to delete this knowledge base entry?" },
+            { x => x.ActionButtonText, "Confirm" }
+        };
+        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
+        IDialogReference dialogRef = await DialogService.ShowAsync<ConfirmDialog>("Confirm", dialog, options);
+        DialogResult dialogResult = await dialogRef.Result;
+
+        if (!dialogResult.Canceled)
         {
-            Snackbar.Add("Error deleting knowledge entry.", Severity.Error);
+            var result = await KnowledgeService.DeleteKnowledgeEntryAsync(id);
+            if (result)
+            {
+                Snackbar.Add("Knowledge entry deleted.", Severity.Success);
+            }
+            else
+            {
+                Snackbar.Add("Error deleting knowledge entry.", Severity.Error);
+            }
+            await LoadKnowledgeEntries();
         }
-        await LoadKnowledgeEntries();
     }
 
     private async Task AddKnowledgeGroup()
@@ -276,17 +288,29 @@
 
     private async Task DeleteKnowledgeGroup(Guid id)
     {
-        var result = await KnowledgeService.DeleteKnowledgeGroupAsync(id);
-        if (result)
+        DialogParameters<ConfirmDialog> dialog = new()
         {
-            Snackbar.Add("Knowledge group deleted.", Severity.Success);
-        }
-        else
+            { x => x.ContentText, $"Are you sure you want to delete this knowledge base group?" },
+            { x => x.ActionButtonText, "Confirm" }
+        };
+        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
+        IDialogReference dialogRef = await DialogService.ShowAsync<ConfirmDialog>("Confirm", dialog, options);
+        DialogResult dialogResult = await dialogRef.Result;
+
+        if (!dialogResult.Canceled)
         {
-            Snackbar.Add("Error deleting knowledge group.", Severity.Error);
+            var result = await KnowledgeService.DeleteKnowledgeGroupAsync(id);
+            if (result)
+            {
+                Snackbar.Add("Knowledge group deleted.", Severity.Success);
+            }
+            else
+            {
+                Snackbar.Add("Error deleting knowledge group.", Severity.Error);
+            }
+            await LoadKnowledgeGroups();
+            await LoadKnowledgeEntries();
         }
-        await LoadKnowledgeGroups();
-        await LoadKnowledgeEntries();
     }
 
 }

--- a/src/Eurofurence.App.Backoffice/Services/ArtistAlleyService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/ArtistAlleyService.cs
@@ -20,5 +20,10 @@ namespace Eurofurence.App.Backoffice.Services
             JsonContent content = JsonContent.Create(state);
             HttpResponseMessage res = await http.PutAsync($"ArtistsAlley/{record.Id}/:status", content);
         }
+
+        public async Task DeleteTableRegistrationAsync(TableRegistrationRecord record)
+        {
+            await http.DeleteAsync($"ArtistsAlley/{record.Id}");
+        }
     }
 }

--- a/src/Eurofurence.App.Backoffice/Services/ArtistAlleyService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/ArtistAlleyService.cs
@@ -13,5 +13,12 @@ namespace Eurofurence.App.Backoffice.Services
             options.Converters.Add(new JsonStringEnumConverter());
             return (await http.GetFromJsonAsync<TableRegistrationRecord[]>("ArtistsAlley", options))?.Where(ke => ke.IsDeleted != 1).ToArray() ?? [];
         }
+
+        public async Task PutTableRegistrationStatusAsync(TableRegistrationRecord record,
+            TableRegistrationRecord.RegistrationStateEnum state)
+        {
+            JsonContent content = JsonContent.Create(state);
+            HttpResponseMessage res = await http.PutAsync($"ArtistsAlley/{record.Id}/:status", content);
+        }
     }
 }

--- a/src/Eurofurence.App.Backoffice/Services/IArtistAlleyService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/IArtistAlleyService.cs
@@ -4,6 +4,18 @@ namespace Eurofurence.App.Backoffice.Services
 {
     public interface IArtistAlleyService
     {
+        /// <summary>
+        /// Send a query to the api and retrieve all registrations for the artist alley
+        /// </summary>
+        /// <returns>The list of found database entries</returns>
         public Task<TableRegistrationRecord[]> GetTableRegistrationsAsync();
+
+        /// <summary>
+        /// Changes the status of a given artist alley registration <paramref name="record"/>
+        /// </summary>
+        /// <param name="record">The record that should be updated</param>
+        /// <param name="state"></param>
+        /// <returns></returns>
+        public Task PutTableRegistrationStatusAsync(TableRegistrationRecord record, TableRegistrationRecord.RegistrationStateEnum state);
     }
 }

--- a/src/Eurofurence.App.Backoffice/Services/IArtistAlleyService.cs
+++ b/src/Eurofurence.App.Backoffice/Services/IArtistAlleyService.cs
@@ -17,5 +17,12 @@ namespace Eurofurence.App.Backoffice.Services
         /// <param name="state"></param>
         /// <returns></returns>
         public Task PutTableRegistrationStatusAsync(TableRegistrationRecord record, TableRegistrationRecord.RegistrationStateEnum state);
+
+        /// <summary>
+        /// Deletes a given <see cref="TableRegistrationRecord"/>
+        /// </summary>
+        /// <param name="record">The record to delete</param>
+        /// <returns></returns>
+        public Task DeleteTableRegistrationAsync(TableRegistrationRecord record);
     }
 }

--- a/src/Eurofurence.App.Domain.Model/ArtistsAlley/TableRegistrationRecord.cs
+++ b/src/Eurofurence.App.Domain.Model/ArtistsAlley/TableRegistrationRecord.cs
@@ -59,7 +59,7 @@ namespace Eurofurence.App.Domain.Model.ArtistsAlley
         public RegistrationStateEnum State { get; set; }
 
         [JsonIgnore]
-        public IList<StateChangeRecord> StateChangeLog { get; set; }
+        public virtual IList<StateChangeRecord> StateChangeLog { get; set; }
 
         public TableRegistrationRecord()
         {
@@ -68,13 +68,13 @@ namespace Eurofurence.App.Domain.Model.ArtistsAlley
 
         public void ChangeState(RegistrationStateEnum newState, string uid)
         {
-            StateChangeLog.Add(new StateChangeRecord()
-            {
-                ChangedByUid = uid,
-                ChangedDateTimeUtc = DateTime.UtcNow,
-                NewState = newState,
-                OldState = State
-            });
+            // StateChangeLog.Add(new StateChangeRecord()
+            // {
+            //     ChangedByUid = uid,
+            //     ChangedDateTimeUtc = DateTime.UtcNow,
+            //     NewState = newState,
+            //     OldState = State
+            // });
 
             State = newState;
         }

--- a/src/Eurofurence.App.Server.Services/ArtistsAlley/TableRegistrationService.cs
+++ b/src/Eurofurence.App.Server.Services/ArtistsAlley/TableRegistrationService.cs
@@ -105,7 +105,8 @@ namespace Eurofurence.App.Server.Services.ArtistsAlley
         {
             var record = await _appDbContext.TableRegistrations.FirstOrDefaultAsync(a => a.Id == id
                                                                            && a.State == TableRegistrationRecord.RegistrationStateEnum.Pending);
-            record.ChangeState(TableRegistrationRecord.RegistrationStateEnum.Accepted, operatorUid);
+            var stateChange =record.ChangeState(TableRegistrationRecord.RegistrationStateEnum.Accepted, operatorUid);
+            _appDbContext.StateChangeRecord.Add(stateChange);
             record.Touch();
 
             await _telegramMessageSender.SendMarkdownMessageToChatAsync(
@@ -176,7 +177,9 @@ namespace Eurofurence.App.Server.Services.ArtistsAlley
             var record = await _appDbContext.TableRegistrations.FirstOrDefaultAsync(a => a.Id == id
                 && a.State == TableRegistrationRecord.RegistrationStateEnum.Pending);
 
-            record.ChangeState(TableRegistrationRecord.RegistrationStateEnum.Rejected, operatorUid);
+            var stateChange = record.ChangeState(TableRegistrationRecord.RegistrationStateEnum.Rejected, operatorUid);
+            _appDbContext.StateChangeRecord.Add(stateChange);
+
             record.Touch();
 
             await _telegramMessageSender.SendMarkdownMessageToChatAsync(_configuration.TelegramAdminGroupChatId,

--- a/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
@@ -27,11 +27,13 @@ namespace Eurofurence.App.Server.Web.Controllers
         }
 
         [HttpPut("{id}/:status")]
+        [Authorize(Roles = "Admin, ArtistAlleyAdmin")]
         public async Task<ActionResult> PutTableRegistrationStatusAsync([EnsureNotNull] [FromRoute] Guid id,
             [FromBody] TableRegistrationRecord.RegistrationStateEnum state)
         {
-            TableRegistrationRecord record = await _tableRegistrationService.GetLatestRegistrationByUidAsync(User.GetSubject());
-
+            TableRegistrationRecord record =
+                await _tableRegistrationService.GetLatestRegistrationByUidAsync(User.GetSubject());
+            // Return 404 if the passed id does not exist
             if (record == null)
             {
                 return NotFound();

--- a/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
@@ -39,11 +39,11 @@ namespace Eurofurence.App.Server.Web.Controllers
 
             if (state == TableRegistrationRecord.RegistrationStateEnum.Rejected)
             {
-                _tableRegistrationService.RejectByIdAsync(id, "API:" + User.Identity.Name);
+                await _tableRegistrationService.RejectByIdAsync(id, "API:" + User.Identity.Name);
             }
             else if (state == TableRegistrationRecord.RegistrationStateEnum.Accepted)
             {
-                _tableRegistrationService.ApproveByIdAsync(id, "API:" + User.Identity.Name);
+                await _tableRegistrationService.ApproveByIdAsync(id, "API:" + User.Identity.Name);
             }
 
             return NoContent();

--- a/src/Eurofurence.App.Server.Web/Identity/AuthorizationOptions.cs
+++ b/src/Eurofurence.App.Server.Web/Identity/AuthorizationOptions.cs
@@ -5,6 +5,7 @@ namespace Eurofurence.App.Server.Web.Identity;
 public class AuthorizationOptions
 {
     public HashSet<string> Admin { get; set; } = new();
+
     public HashSet<string> Attendee { get; set; } = new();
     public HashSet<string> AttendeeCheckedIn { get; set; } = new();
 
@@ -15,6 +16,12 @@ public class AuthorizationOptions
     public HashSet<string> ArtShow { get; set; } = new();
 
     public HashSet<string> FursuitBadgeSystem { get; set; } = new();
+
+    /// <summary>
+    /// Artist alley moderators may approve or reject table applications from attendees.
+    ///
+    /// </summary>
+    public HashSet<string> ArtistAlleyModerator { get; set; } = new();
 
     public HashSet<string> PrivateMessageSender { get; set; } = new();
 }

--- a/src/Eurofurence.App.Server.Web/Identity/RolesClaimsTransformation.cs
+++ b/src/Eurofurence.App.Server.Web/Identity/RolesClaimsTransformation.cs
@@ -85,6 +85,11 @@ public class RolesClaimsTransformation(
             {
                 roles.Add("AttendeeCheckedIn");
             }
+
+            if (authorizationOptions.Value.ArtistAlleyModerator.Contains(claim.Value))
+            {
+                roles.Add("ArtistAlleyModerator");
+            }
         }
 
         foreach (var role in roles)

--- a/src/Eurofurence.App.Server.Web/appsettings.sample.json
+++ b/src/Eurofurence.App.Server.Web/appsettings.sample.json
@@ -6,6 +6,8 @@
     "RegSysUrl": ""
   },
   "Authorization": {
+    "ArtistAlleyAdmin": [],
+    "ArtistAlleyModerator": [],
     "ArtShow": [],
     "PrivateMessageSender": [],
     "KnowledgeBaseEditor": [],

--- a/test/Eurofurence.App.Server.Services.Tests/Eurofurence.App.Server.Services.Tests.csproj
+++ b/test/Eurofurence.App.Server.Services.Tests/Eurofurence.App.Server.Services.Tests.csproj
@@ -4,9 +4,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">


### PR DESCRIPTION
This PR adds artist alley management to the backoffice, introducing a new API endpoint for setting the artist alley table registration status, aswell as two new access roles, solving #160 .

It also adds a confirm dialog when trying to delete entities.

Thanks to @maakinoh for building the artist alley management :)