### PR TITLE
fix(push): Allow registering devices without login and re-registration

### DIFF
--- a/src/Eurofurence.App.Domain.Model/PushNotifications/DeviceIdentityRecord.cs
+++ b/src/Eurofurence.App.Domain.Model/PushNotifications/DeviceIdentityRecord.cs
@@ -5,7 +5,6 @@ namespace Eurofurence.App.Domain.Model.PushNotifications;
 
 public class DeviceIdentityRecord : EntityBase
 {
-    [Required]
     [DataMember]
     public string IdentityId { get; set; }
 

--- a/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240828192551_DeviceIdentityRecordIdentityIdOptional.Designer.cs
+++ b/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240828192551_DeviceIdentityRecordIdentityIdOptional.Designer.cs
@@ -4,6 +4,7 @@ using Eurofurence.App.Infrastructure.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Eurofurence.App.Infrastructure.EntityFramework.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240828192551_DeviceIdentityRecordIdentityIdOptional")]
+    partial class DeviceIdentityRecordIdentityIdOptional
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240828192551_DeviceIdentityRecordIdentityIdOptional.cs
+++ b/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20240828192551_DeviceIdentityRecordIdentityIdOptional.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eurofurence.App.Infrastructure.EntityFramework.Migrations
+{
+    /// <inheritdoc />
+    public partial class DeviceIdentityRecordIdentityIdOptional : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "IdentityId",
+                table: "DeviceIdentities",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "longtext")
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "DeviceIdentities",
+                keyColumn: "IdentityId",
+                keyValue: null,
+                column: "IdentityId",
+                value: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "IdentityId",
+                table: "DeviceIdentities",
+                type: "longtext",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/src/Eurofurence.App.Server.Services/PushNotifications/FirebaseChannelManager.cs
+++ b/src/Eurofurence.App.Server.Services/PushNotifications/FirebaseChannelManager.cs
@@ -21,7 +21,7 @@ namespace Eurofurence.App.Server.Services.PushNotifications
     {
         private readonly IDeviceIdentityService _deviceService;
         private readonly IRegistrationIdentityService _registrationService;
-        private readonly AppDbContext _db;
+        private readonly AppDbContext _appDbContext;
         private readonly FirebaseConfiguration _configuration;
         private readonly ConventionSettings _conventionSettings;
         private readonly FirebaseApp _firebaseApp;
@@ -30,13 +30,13 @@ namespace Eurofurence.App.Server.Services.PushNotifications
         public FirebaseChannelManager(
             IDeviceIdentityService deviceService,
             IRegistrationIdentityService registrationService,
-            AppDbContext db,
+            AppDbContext appDbContext,
             FirebaseConfiguration configuration,
             ConventionSettings conventionSettings)
         {
             _deviceService = deviceService;
             _registrationService = registrationService;
-            _db = db;
+            _appDbContext = appDbContext;
             _configuration = configuration;
             _conventionSettings = conventionSettings;
 
@@ -210,7 +210,7 @@ namespace Eurofurence.App.Server.Services.PushNotifications
             DeviceType type,
             CancellationToken cancellationToken = default)
         {
-            var existing = await _db.DeviceIdentities
+            var existing = await _appDbContext.DeviceIdentities
                 .Where(x => x.DeviceToken == deviceToken)
                 .ToListAsync(cancellationToken);
 
@@ -222,7 +222,7 @@ namespace Eurofurence.App.Server.Services.PushNotifications
                     identity.Touch();
                 }
 
-                await _db.SaveChangesAsync(cancellationToken);
+                await _appDbContext.SaveChangesAsync(cancellationToken);
             }
             else
             {


### PR DESCRIPTION
Allows adding device without an IdentityId and re-registering devices under a new IdentityId