### PR TITLE
fix(pm): fix crash when reading private messages

### DIFF
--- a/src/Eurofurence.App.Server.Web/Identity/RolesClaimsTransformation.cs
+++ b/src/Eurofurence.App.Server.Web/Identity/RolesClaimsTransformation.cs
@@ -249,6 +249,7 @@ public class RolesClaimsTransformation(
         var newIds = new HashSet<string>(ids);
 
         var existingIds = await db.RegistrationIdentities
+            .AsNoTracking()
             .Where(x => newIds.Contains(x.RegSysId))
             .Select(x => x.RegSysId)
             .ToListAsync();

--- a/src/Eurofurence.App.Server.Web/Startup.cs
+++ b/src/Eurofurence.App.Server.Web/Startup.cs
@@ -173,7 +173,7 @@ namespace Eurofurence.App.Server.Web
 
             services.Configure<LoggerFilterOptions>(options => { options.MinLevel = LogLevel.Trace; });
 
-            services.AddDbContext<AppDbContext>(options =>
+            services.AddDbContextPool<AppDbContext>(options =>
             {
                 var connectionString = Configuration.GetConnectionString("Eurofurence");
 

--- a/src/Eurofurence.App.Server.Web/Startup.cs
+++ b/src/Eurofurence.App.Server.Web/Startup.cs
@@ -173,7 +173,7 @@ namespace Eurofurence.App.Server.Web
 
             services.Configure<LoggerFilterOptions>(options => { options.MinLevel = LogLevel.Trace; });
 
-            services.AddDbContextPool<AppDbContext>(options =>
+            services.AddDbContext<AppDbContext>(options =>
             {
                 var connectionString = Configuration.GetConnectionString("Eurofurence");
 


### PR DESCRIPTION
Fixes a crash when reading privates messages, by changing how `PrivateMessageService` reads pending private messages and disabling `DBContext` pooling