### PR TITLE
fix(dealers): exclude unwanted fields from API

### DIFF
--- a/src/Eurofurence.App.Domain.Model/Dealers/DealerRecord.cs
+++ b/src/Eurofurence.App.Domain.Model/Dealers/DealerRecord.cs
@@ -26,7 +26,7 @@ namespace Eurofurence.App.Domain.Model.Dealers
         [Required]
         [DataMember]
         [JsonIgnore]
-        public int RegistrationNumber { get; set; }
+        public int RegistrationNumber { get; set; } = -1;
 
         /// <summary>
         /// Nickname number (as on badge) of the attendee that acts on behalf/represents this dealer.
@@ -35,7 +35,7 @@ namespace Eurofurence.App.Domain.Model.Dealers
         [Required]
         [DataMember]
         [JsonIgnore]
-        public string AttendeeNickname { get; set; }
+        public string AttendeeNickname { get; set; } = "";
 
         /// <summary>
         /// **(pba)** Name under which this dealer is acting, e.G. name of the company or brand. 

--- a/src/Eurofurence.App.Domain.Model/Dealers/DealerRecord.cs
+++ b/src/Eurofurence.App.Domain.Model/Dealers/DealerRecord.cs
@@ -22,6 +22,7 @@ namespace Eurofurence.App.Domain.Model.Dealers
         /// <summary>
         /// Registration number (as on badge) of the attendee that acts on behalf/represents this dealer.
         /// </summary>
+        // TODO: Remove entirely for EF29
         [Required]
         [DataMember]
         [JsonIgnore]
@@ -30,6 +31,7 @@ namespace Eurofurence.App.Domain.Model.Dealers
         /// <summary>
         /// Nickname number (as on badge) of the attendee that acts on behalf/represents this dealer.
         /// </summary>
+        // TODO: Remove entirely for EF29
         [Required]
         [DataMember]
         [JsonIgnore]
@@ -174,6 +176,7 @@ namespace Eurofurence.App.Domain.Model.Dealers
         [DataMember]
         public Dictionary<string, string[]> Keywords { get; set; }
 
+        // TODO: Remove entirely for EF29 (superseded by making DisplayName Required and using it exclusively)
         public string DisplayNameOrAttendeeNickname =>
             !string.IsNullOrWhiteSpace(DisplayName) ? DisplayName : AttendeeNickname;
     }

--- a/src/Eurofurence.App.Domain.Model/Dealers/DealerRecord.cs
+++ b/src/Eurofurence.App.Domain.Model/Dealers/DealerRecord.cs
@@ -24,6 +24,7 @@ namespace Eurofurence.App.Domain.Model.Dealers
         /// </summary>
         [Required]
         [DataMember]
+        [JsonIgnore]
         public int RegistrationNumber { get; set; }
 
         /// <summary>
@@ -31,6 +32,7 @@ namespace Eurofurence.App.Domain.Model.Dealers
         /// </summary>
         [Required]
         [DataMember]
+        [JsonIgnore]
         public string AttendeeNickname { get; set; }
 
         /// <summary>


### PR DESCRIPTION
* `AttendeeNickname` should only be exposed via `DisplayNameOrAttendeeNickname` if `DisplayName` is not set.
* `RegistrationNumber` should _never_ be exposed.