### PR TITLE
fix(logging): reduce logging for requests

### DIFF
--- a/src/Eurofurence.App.Server.Web/Controllers/DealersController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/DealersController.cs
@@ -13,7 +13,6 @@ using MapsterMapper;
 namespace Eurofurence.App.Server.Web.Controllers
 {
     [Route("Api/[controller]")]
-    [AllowAnonymous]
     public class DealersController : BaseController
     {
         private readonly IDealerService _dealerService;

--- a/src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj
+++ b/src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Serilog" Version="4.0.1" />
     <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />

--- a/src/Eurofurence.App.Server.Web/Startup.cs
+++ b/src/Eurofurence.App.Server.Web/Startup.cs
@@ -1,6 +1,5 @@
 ﻿using Autofac;
 using Eurofurence.App.Server.Services.Abstractions;
-using Eurofurence.App.Server.Services.Abstractions.Fursuits;
 using Eurofurence.App.Server.Web.Extensions;
 using Eurofurence.App.Server.Web.Jobs;
 using Eurofurence.App.Server.Web.Swagger;
@@ -15,7 +14,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Context;
-using Serilog.Events;
 using Swashbuckle.AspNetCore.SwaggerUI;
 using System;
 using System.Text.Json;
@@ -359,58 +357,7 @@ namespace Eurofurence.App.Server.Web
             IHostApplicationLifetime appLifetime
         )
         {
-            var loggerConfiguration = new LoggerConfiguration().Enrich.FromLogContext();
-
-            var consoleLogLevel = env.IsDevelopment() ? LogEventLevel.Debug : LogEventLevel.Information;
-
-            loggerConfiguration
-                .WriteTo.Console(
-                    restrictedToMinimumLevel: consoleLogLevel,
-                    outputTemplate:
-                    "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{IPAddress}] [{Level}] {Message}{NewLine}{Exception}");
-
-            if (!string.IsNullOrEmpty(Configuration["auditLog"]))
-            {
-                loggerConfiguration
-                    .WriteTo
-                    .Logger(lc =>
-                        lc.Filter
-                            .ByIncludingOnly($"EventId.Id = {LogEvents.Audit.Id}")
-                            .WriteTo.File(Configuration["auditLog"],
-                                restrictedToMinimumLevel: LogEventLevel.Verbose,
-                                outputTemplate:
-                                "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{IPAddress}] [{Level}] {Message}{NewLine}{Exception}"
-                            )
-                    );
-            }
-
-            var cgc = new CollectionGameConfiguration();
-            Configuration.GetSection(CollectionGameConfiguration.CollectionGame).Bind(cgc);
-
-            if (!string.IsNullOrEmpty(cgc.LogFile))
-            {
-                loggerConfiguration
-                    .WriteTo
-                    .Logger(lc =>
-                        lc.Filter
-                            .ByIncludingOnly($"EventId.Id = {LogEvents.CollectionGame.Id}")
-                            .WriteTo.File(cgc.LogFile, (LogEventLevel)cgc.LogLevel)
-                    );
-            }
-            
-            if (!string.IsNullOrEmpty(Configuration["importLog"]))
-            {
-                loggerConfiguration
-                    .WriteTo
-                    .Logger(lc =>
-                        lc.Filter
-                            .ByIncludingOnly($"EventId.Id = {LogEvents.Import.Id}")
-                            .WriteTo.File(Configuration["importLog"],
-                                restrictedToMinimumLevel: LogEventLevel.Verbose
-                            )
-                    );
-            }
-            
+            var loggerConfiguration = new LoggerConfiguration().ReadFrom.Configuration(Configuration);
             Log.Logger = loggerConfiguration.CreateLogger();
 
             loggerFactory

--- a/src/Eurofurence.App.Server.Web/appsettings.sample.json
+++ b/src/Eurofurence.App.Server.Web/appsettings.sample.json
@@ -31,17 +31,24 @@
     "Eurofurence": "Server=db; Port=3306; Database=ef_backend; user=root; SslMode=Preferred;"
   },
   "Serilog": {
-    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
+    "Using": [
+      "Serilog.Sinks.Console",
+      "Serilog.Sinks.File"
+    ],
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information"
+        "Microsoft.Hosting.Lifetime": "Information",
+        "System.Net.Http.HttpClient": "Warning"
       }
     },
     "WriteTo": [
       {
-        "Name": "Console"
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] [{IPAddress}] {Message}{NewLine}{Exception}"
+        }
       },
       {
         "Name": "File",
@@ -50,7 +57,9 @@
         }
       }
     ],
-    "Enrich": [ "FromLogContext" ]
+    "Enrich": [
+      "FromLogContext"
+    ]
   },
   "firebase": {
     "googleServiceCredentialKeyFile": "firebase.json",

--- a/src/Eurofurence.App.Server.Web/appsettings.sample.json
+++ b/src/Eurofurence.App.Server.Web/appsettings.sample.json
@@ -30,15 +30,27 @@
   "ConnectionStrings": {
     "Eurofurence": "Server=db; Port=3306; Database=ef_backend; user=root; SslMode=Preferred;"
   },
-  "oAuth": {
-    "issuer": "EurofurenceAppWebApi",
-    "audience": "EurofurenceAppWebApi",
-    "secretKey": "LynxesAreAwesomeAndHaveFuzzyEartuftsAndThisIsTotallyNotTheTokenUsedInTheLiveEnvironment"
-  },
-  "wns": {
-    "clientId": "",
-    "clientSecret": "",
-    "targetTopic": "Debug"
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      },
+      {
+        "Name": "File",
+        "Args": {
+          "path": "/tmp/log.txt"
+        }
+      }
+    ],
+    "Enrich": [ "FromLogContext" ]
   },
   "firebase": {
     "googleServiceCredentialKeyFile": "firebase.json",
@@ -53,10 +65,6 @@
   "telegram": {
     "accessToken": "",
     "proxy": ""
-  },
-  "collectionGame": {
-    "logLevel": 1,
-    "logFile": "/tmp/collect.log"
   },
   "artistAlley": {
     "telegram": {


### PR DESCRIPTION
I moved the Serilog configuration from the startup.cs to the appsettings.json file and added an example configuration to the appsettings.sample.json, that logs with a minimum level of "Information", excluding Microsoft-internal logs, e.g. during API requests, these will only by logged with a loglevel of Warning or higher.