### PR TITLE
fix: sort knowledge entries by order & show indicator in overview

### DIFF
--- a/justfile
+++ b/justfile
@@ -65,8 +65,11 @@ containerize SERVICE="" *ARGS="":
 	docker compose build {{ARGS}} {{SERVICE}}
 	if [[ $(docker compose ps --services --status running | wc -w) -gt 0 ]]; then
 		echo "Detected running stack! Refreshing service {{SERVICE}} …"
-		docker compose create --force-recreate {{SERVICE}} && docker compose start {{SERVICE}}
+		just recreate {{SERVICE}}
 	fi
+
+recreate SERVICE="":
+	docker compose create --force-recreate {{SERVICE}} && docker compose start {{SERVICE}}
 
 # Build sdk container for backend without executing second stage
 containerize-dev:

--- a/src/Eurofurence.App.Backoffice/Layout/MainLayout.razor
+++ b/src/Eurofurence.App.Backoffice/Layout/MainLayout.razor
@@ -32,6 +32,7 @@
             {
                 Primary = "#69a3a2",
                 Secondary = "#a2c5c4",
+                Tertiary = "#dedede",
                 AppbarBackground = "#005953",
             }
         };

--- a/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
@@ -1,4 +1,4 @@
-﻿@page "/knowledgebase"
+@page "/knowledgebase"
 @attribute [Authorize(Policy = "RequireKnowledgeBaseEditor")]
 @using Eurofurence.App.Backoffice.Services
 @using Eurofurence.App.Domain.Model.Knowledge
@@ -45,28 +45,24 @@
             {
                 <MudListItem @onclick="() => _selectedGroup = knowledgeGroup">
                     <MudCard Style="background-color: transparent">
-                        <MudCardHeader>
-                            <CardHeaderAvatar>
-                                <MudIcon Icon="@("fas fa-" + knowledgeGroup.FontAwesomeIconName)"></MudIcon>
-                            </CardHeaderAvatar>
-                            <CardHeaderContent>
-                                <MudGrid>
-                                    <MudItem>
-                                        <MudText Typo="Typo.h6">@knowledgeGroup.Name</MudText>
-                                    </MudItem>
-                                    <MudSpacer></MudSpacer>
-                                    <MudItem>
-                                        <MudText Class="mb-4 mr-4" Typo="Typo.h6" Color="Color.Tertiary">#@knowledgeGroup.Order</MudText>
-                                    </MudItem>
-                                </MudGrid>
-                            </CardHeaderContent>
-                            <CardHeaderActions>
-                                <MudIconButton Icon="@Icons.Material.Filled.Edit"
-                                               @onclick="() => UpdateKnowledgeGroup(knowledgeGroup)"></MudIconButton>
-                                <MudIconButton Icon="@Icons.Material.Filled.Delete"
-                                               @onclick="() => DeleteKnowledgeGroup(knowledgeGroup.Id)"></MudIconButton>
-                            </CardHeaderActions>
-                        </MudCardHeader>
+                        <MudBadge Content="@("#" + knowledgeGroup.Order)" Origin="Origin.TopLeft" Overlap="true">
+                            <MudCardHeader>
+                                <CardHeaderAvatar>
+                                    <MudIcon Icon="@("fas fa-" + knowledgeGroup.FontAwesomeIconName)"></MudIcon>
+                                </CardHeaderAvatar>
+                                <CardHeaderContent>
+                                    <MudText Typo="Typo.h6">@knowledgeGroup.Name</MudText>
+                                </CardHeaderContent>
+                                <CardHeaderActions>
+                                    <MudIconButton Icon="@Icons.Material.Filled.Edit"
+                                                   @onclick="() => UpdateKnowledgeGroup(knowledgeGroup)">
+                                    </MudIconButton>
+                                    <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                                   @onclick="() => DeleteKnowledgeGroup(knowledgeGroup.Id)">
+                                    </MudIconButton>
+                                </CardHeaderActions>
+                            </MudCardHeader>
+                        </MudBadge>
                         <MudCardContent>
                             <MudText>@knowledgeGroup.Description</MudText>
                         </MudCardContent>
@@ -102,30 +98,24 @@
             @foreach (var knowledgeEntry in GetKnowledgeEntities())
             {
                 <MudCard Class="mt-4">
-                    <MudCardHeader>
-                        <CardHeaderContent>
-                            <MudGrid>
-                                <MudItem>
-                                    <MudText Typo="Typo.caption" HtmlTag="h5">@knowledgeEntry.KnowledgeGroup.Name</MudText>
-                                    <MudText Typo="Typo.h6">@knowledgeEntry.Title</MudText>
-                                </MudItem>
-                                <MudSpacer></MudSpacer>
-                                <MudItem>
-                                    <MudText Class="mr-4" Typo="Typo.h6" Color="Color.Tertiary">#@knowledgeEntry.Order</MudText>
-                                </MudItem>
-                            </MudGrid>
-                        </CardHeaderContent>
-                        <CardHeaderActions>
-                            <MudIconButton Icon="@Icons.Material.Filled.OpenInNew"
-                                Href="@GetWebPreviewUrl(["KnowledgeEntries", knowledgeEntry.Id.ToString()])"
-                                Target="_blank">
-                            </MudIconButton>
-                            <MudIconButton Icon="@Icons.Material.Filled.Edit"
-                                           @onclick="() => UpdateKnowledgeEntry(knowledgeEntry)"/>
-                            <MudIconButton Icon="@Icons.Material.Filled.Delete"
-                                           @onclick="() => DeleteKnowledgeEntry(knowledgeEntry.Id)"/>
-                        </CardHeaderActions>
-                    </MudCardHeader>
+                    <MudBadge Content="@("#" + knowledgeEntry.Order)" Origin="Origin.TopLeft" Overlap="true">
+                        <MudCardHeader>
+                            <CardHeaderContent>
+                                <MudText Typo="Typo.caption" HtmlTag="h5">@knowledgeEntry.KnowledgeGroup.Name</MudText>
+                                <MudText Typo="Typo.h6">@knowledgeEntry.Title</MudText>
+                            </CardHeaderContent>
+                            <CardHeaderActions>
+                                <MudIconButton Icon="@Icons.Material.Filled.OpenInNew"
+                                    Href="@GetWebPreviewUrl(["KnowledgeEntries", knowledgeEntry.Id.ToString()])"
+                                    Target="_blank">
+                                </MudIconButton>
+                                <MudIconButton Icon="@Icons.Material.Filled.Edit"
+                                    @onclick="() => UpdateKnowledgeEntry(knowledgeEntry)"/>
+                                <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                    @onclick="() => DeleteKnowledgeEntry(knowledgeEntry.Id)"/>
+                            </CardHeaderActions>
+                        </MudCardHeader>
+                    </MudBadge>
                     <MudCardContent>
                         <MarkdownRenderer Text="@knowledgeEntry.Text"></MarkdownRenderer>
 

--- a/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
@@ -6,7 +6,7 @@
 @using Eurofurence.App.Backoffice.Components
 @using Eurofurence.App.Domain.Model.Fragments
 @using Eurofurence.App.Domain.Model.Images
-@using Markdig
+@inject IConfiguration Configuration
 @inject ISnackbar Snackbar
 @inject IKnowledgeService KnowledgeService
 @inject IImageService ImageService
@@ -19,6 +19,8 @@
         <MudToolBar>
             <MudText Typo="Typo.h6">Groups</MudText>
             <MudSpacer />
+            <MudIconButton Icon="@Icons.Material.Filled.OpenInNew" Href="@GetWebPreviewUrl(["KnowledgeGroups"])">
+            </MudIconButton>
             <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add"
                 @onclick="AddKnowledgeGroup">New Group</MudButton>
         </MudToolBar>
@@ -98,6 +100,10 @@
                             <MudText Typo="Typo.h6">@knowledgeEntry.Title</MudText>
                         </CardHeaderContent>
                         <CardHeaderActions>
+                            <MudIconButton Icon="@Icons.Material.Filled.OpenInNew"
+                                Href="@GetWebPreviewUrl(["KnowledgeEntries", knowledgeEntry.Id.ToString()])"
+                                Target="_blank">
+                            </MudIconButton>
                             <MudIconButton Icon="@Icons.Material.Filled.Edit"
                                 @onclick="() => UpdateKnowledgeEntry(knowledgeEntry)" />
                             <MudIconButton Icon="@Icons.Material.Filled.Delete"
@@ -136,8 +142,8 @@
     public bool Loading = true;
     private string? _knowledgeEntrySearch;
     private KnowledgeGroupRecord? _selectedGroup;
-    private Dictionary<Guid, KnowledgeGroupRecord> _knowledgeGroups = new Dictionary<Guid, KnowledgeGroupRecord>();
-    private List<KnowledgeEntryRecord> _knowledgeEntries = new List<KnowledgeEntryRecord>();
+    private Dictionary<Guid, KnowledgeGroupRecord> _knowledgeGroups = new();
+    private List<KnowledgeEntryRecord> _knowledgeEntries = [];
 
     protected override async Task OnInitializedAsync()
     {
@@ -269,6 +275,12 @@
             }
             await LoadKnowledgeEntries();
         }
+    }
+
+    private string GetWebPreviewUrl(IEnumerable<string> paths)
+    {
+        var webPreviewUrl = $"{Configuration.GetValue<string>("BackendBaseUrl")?.TrimEnd('/') ?? string.Empty}/Web";
+        return paths.Aggregate(webPreviewUrl, (current, path) => $"{current}/{path.TrimStart('/')}");
     }
 
     private async Task AddKnowledgeGroup()

--- a/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/KnowledgeBase.razor
@@ -50,13 +50,21 @@
                                 <MudIcon Icon="@("fas fa-" + knowledgeGroup.FontAwesomeIconName)"></MudIcon>
                             </CardHeaderAvatar>
                             <CardHeaderContent>
-                                <MudText Typo="Typo.h6">@knowledgeGroup.Name</MudText>
+                                <MudGrid>
+                                    <MudItem>
+                                        <MudText Typo="Typo.h6">@knowledgeGroup.Name</MudText>
+                                    </MudItem>
+                                    <MudSpacer></MudSpacer>
+                                    <MudItem>
+                                        <MudText Class="mb-4 mr-4" Typo="Typo.h6" Color="Color.Tertiary">#@knowledgeGroup.Order</MudText>
+                                    </MudItem>
+                                </MudGrid>
                             </CardHeaderContent>
                             <CardHeaderActions>
                                 <MudIconButton Icon="@Icons.Material.Filled.Edit"
-                                    @onclick="() => UpdateKnowledgeGroup(knowledgeGroup)"></MudIconButton>
+                                               @onclick="() => UpdateKnowledgeGroup(knowledgeGroup)"></MudIconButton>
                                 <MudIconButton Icon="@Icons.Material.Filled.Delete"
-                                    @onclick="() => DeleteKnowledgeGroup(knowledgeGroup.Id)"></MudIconButton>
+                                               @onclick="() => DeleteKnowledgeGroup(knowledgeGroup.Id)"></MudIconButton>
                             </CardHeaderActions>
                         </MudCardHeader>
                         <MudCardContent>
@@ -96,8 +104,16 @@
                 <MudCard Class="mt-4">
                     <MudCardHeader>
                         <CardHeaderContent>
-                            <MudText Typo="Typo.caption" HtmlTag="h5">@knowledgeEntry.KnowledgeGroup.Name</MudText>
-                            <MudText Typo="Typo.h6">@knowledgeEntry.Title</MudText>
+                            <MudGrid>
+                                <MudItem>
+                                    <MudText Typo="Typo.caption" HtmlTag="h5">@knowledgeEntry.KnowledgeGroup.Name</MudText>
+                                    <MudText Typo="Typo.h6">@knowledgeEntry.Title</MudText>
+                                </MudItem>
+                                <MudSpacer></MudSpacer>
+                                <MudItem>
+                                    <MudText Class="mr-4" Typo="Typo.h6" Color="Color.Tertiary">#@knowledgeEntry.Order</MudText>
+                                </MudItem>
+                            </MudGrid>
                         </CardHeaderContent>
                         <CardHeaderActions>
                             <MudIconButton Icon="@Icons.Material.Filled.OpenInNew"
@@ -105,9 +121,9 @@
                                 Target="_blank">
                             </MudIconButton>
                             <MudIconButton Icon="@Icons.Material.Filled.Edit"
-                                @onclick="() => UpdateKnowledgeEntry(knowledgeEntry)" />
+                                           @onclick="() => UpdateKnowledgeEntry(knowledgeEntry)"/>
                             <MudIconButton Icon="@Icons.Material.Filled.Delete"
-                                @onclick="() => DeleteKnowledgeEntry(knowledgeEntry.Id)" />
+                                           @onclick="() => DeleteKnowledgeEntry(knowledgeEntry.Id)"/>
                         </CardHeaderActions>
                     </MudCardHeader>
                     <MudCardContent>
@@ -156,7 +172,8 @@
         Loading = true;
         _knowledgeEntries = [];
 
-        var responses = (await KnowledgeService.GetKnowledgeEntriesAsync()).OrderBy(ke => ke.Order);
+        var responses = (await KnowledgeService.GetKnowledgeEntriesAsync()).OrderBy(ke => _knowledgeGroups.FirstOrDefault(kg => kg.Key == ke.KnowledgeGroupId).Value.Order).ThenBy(ke => ke.Order);
+        
         foreach (var response in responses)
         {
             var record = new KnowledgeEntryRecord()
@@ -295,6 +312,7 @@
         {
             Loading = true;
             await LoadKnowledgeGroups();
+            await LoadKnowledgeEntries();
         }
     }
 
@@ -310,6 +328,7 @@
         {
             Loading = true;
             await LoadKnowledgeGroups();
+            await LoadKnowledgeEntries();
         }
     }
 

--- a/src/Eurofurence.App.Backoffice/Program.cs
+++ b/src/Eurofurence.App.Backoffice/Program.cs
@@ -23,7 +23,7 @@ builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<TokenAuthorizationMessageHandler>();
 builder.Services.AddHttpClient("api", options =>
 {
-    options.BaseAddress = new Uri(builder.Configuration.GetValue<string>("ApiUrl") ?? string.Empty);
+    options.BaseAddress = new Uri($"{builder.Configuration.GetValue<string>("BackendBaseUrl")?.TrimEnd('/') ?? string.Empty}/Api/");
 }).AddHttpMessageHandler<TokenAuthorizationMessageHandler>();
 
 builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient("api"));

--- a/src/Eurofurence.App.Backoffice/wwwroot/appsettings.sample.json
+++ b/src/Eurofurence.App.Backoffice/wwwroot/appsettings.sample.json
@@ -1,5 +1,5 @@
 {
-  "ApiUrl": "http://localhost:7371/api/",
+  "BackendBaseUrl": "http://localhost:7371/",
   "Oidc": {
     "Authority": "https://identity.eurofurence.org/",
     "ClientId": "<client-id>"


### PR DESCRIPTION
Knowledge entries are now ordered first by their groups order number and then by their own.
Also, there is now an indicator of the order number in the overview.