### PR TITLE
feat: delete aleady aproved/rejected artist alley applications

### DIFF
--- a/src/Eurofurence.App.Backoffice/Components/ArtistAlleyApplicationDialog.razor
+++ b/src/Eurofurence.App.Backoffice/Components/ArtistAlleyApplicationDialog.razor
@@ -14,34 +14,23 @@
                     <MudItem xs="6">
                         <MudLink Href="@Record.Image.Url">
                             <MudImage ObjectFit="ObjectFit.Contain" Height="500" Width="500" Class="ml-2"
-                                Src="@Record.Image.Url" />
+                                      Src="@Record.Image.Url"/>
                         </MudLink>
                     </MudItem>
                 }
                 <MudItem xs="6">
-                    <MudTextField ReadOnly="true" Value="Record.Id" Label="ID" />
-                    <MudTextField ReadOnly="true" Value="Record.CreatedDateTimeUtc" Label="Application submitted at" Format="yyyy-MM-dd HH:mm:ss zzz" />
-                    <MudTextField ReadOnly="true" Value="Record.OwnerUid" Label="Applicant UID" />
-                    <MudTextField ReadOnly="true" Value="Record.OwnerUsername" Label="Applicant's username" />
-                    <MudTextField ReadOnly="true" Value="Record.WebsiteUrl" Label="Applicants Website" />
-                    <MudTextField ReadOnly="true" AutoGrow Value="Record.ShortDescription" Label="Short Description" />
-                    <MudTextField ReadOnly="true" Value="Record.TelegramHandle" Label="Applicant's Telegram handle" />
-                    <MudTextField ReadOnly="true" Value="Record.Location" Label="Location" Class="mb-4" />
+                    <MudTextField ReadOnly="true" Value="Record.Id" Label="ID"/>
+                    <MudTextField ReadOnly="true" Value="Record.CreatedDateTimeUtc" Label="Application submitted at" Format="yyyy-MM-dd HH:mm:ss zzz"/>
+                    <MudTextField ReadOnly="true" Value="Record.OwnerUid" Label="Applicant UID"/>
+                    <MudTextField ReadOnly="true" Value="Record.OwnerUsername" Label="Applicant's username"/>
+                    <MudTextField ReadOnly="true" Value="Record.WebsiteUrl" Label="Applicants Website"/>
+                    <MudTextField ReadOnly="true" AutoGrow Value="Record.ShortDescription" Label="Short Description"/>
+                    <MudTextField ReadOnly="true" Value="Record.TelegramHandle" Label="Applicant's Telegram handle"/>
+                    <MudTextField ReadOnly="true" Value="Record.Location" Label="Location" Class="mb-4"/>
                     @switch (Record.State)
                     {
                         case TableRegistrationRecord.RegistrationStateEnum.Pending:
                             <MudAlert Severity="Severity.Info">Pending</MudAlert>
-                            <MudButton Color="Color.Success" StartIcon="@Icons.Material.Filled.CheckCircle"
-                                @onclick="() => TryChangeRegistrationStatus(Record, false)">Approve</MudButton>
-                            <MudButton Color="Color.Warning" StartIcon="@Icons.Material.Filled.Cancel"
-                                @onclick="() => TryChangeRegistrationStatus(Record, true)">Reject</MudButton>
-                            @*Show the delete button only for admins*@
-                            <AuthorizeView Policy="RequireArtistAlleyAdmin">
-                                <Authorized>
-                                    <MudButton Color="Color.Error" StartIcon="@Icons.Material.Filled.Delete" OnClick="args => DeleteRegistration()">
-                                        Delete</MudButton>
-                                </Authorized>
-                            </AuthorizeView>
                             break;
                         case TableRegistrationRecord.RegistrationStateEnum.Accepted:
                             <MudAlert Severity="Severity.Success">Accepted</MudAlert>
@@ -53,6 +42,26 @@
                             <MudAlert Severity="Severity.Success">Published</MudAlert>
                             break;
                     }
+                    @if (Record.State == TableRegistrationRecord.RegistrationStateEnum.Pending)
+                    {
+
+                        <MudButton Color="Color.Success" StartIcon="@Icons.Material.Filled.CheckCircle"
+                                   @onclick="() => TryChangeRegistrationStatus(Record, false)">
+                            Approve
+                        </MudButton>
+                        <MudButton Color="Color.Warning" StartIcon="@Icons.Material.Filled.Cancel"
+                                   @onclick="() => TryChangeRegistrationStatus(Record, true)">
+                            Reject
+                        </MudButton>
+                    }
+                    @*Show the delete button only for admins*@
+                    <AuthorizeView Policy="RequireArtistAlleyAdmin">
+                        <Authorized>
+                            <MudButton Color="Color.Error" StartIcon="@Icons.Material.Filled.Delete" OnClick="args => DeleteRegistration()">
+                                Delete
+                            </MudButton>
+                        </Authorized>
+                    </AuthorizeView>
                 </MudItem>
             </MudGrid>
         </MudContainer>
@@ -68,10 +77,18 @@
     {
         DialogParameters<ConfirmDialog> dialog = new()
         {
-            { x => x.ContentText, $"Are you sure you want to delete this application?" },
-            { x => x.ActionButtonText, "Confirm" }
+            {
+                x => x.ContentText, $"Are you sure you want to delete this application?"
+            },
+            {
+                x => x.ActionButtonText, "Confirm"
+            }
         };
-        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
+        var options = new DialogOptions()
+        {
+            CloseButton = true,
+            MaxWidth = MaxWidth.ExtraSmall
+        };
         IDialogReference dialogRef = await DialogService.ShowAsync<ConfirmDialog>("Confirm", dialog, options);
         DialogResult? result = await dialogRef.Result;
 
@@ -91,10 +108,18 @@
     {
         DialogParameters<ConfirmDialog> dialog = new()
         {
-            { x => x.ContentText, $"Are you sure you want to {(reject ? "reject" : "approve")} this application?" },
-            { x => x.ActionButtonText, "Confirm" }
+            {
+                x => x.ContentText, $"Are you sure you want to {(reject ? "reject" : "approve")} this application?"
+            },
+            {
+                x => x.ActionButtonText, "Confirm"
+            }
         };
-        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
+        var options = new DialogOptions()
+        {
+            CloseButton = true,
+            MaxWidth = MaxWidth.ExtraSmall
+        };
         IDialogReference dialogRef = await DialogService.ShowAsync<ConfirmDialog>("Confirm", dialog, options);
         DialogResult? result = await dialogRef.Result;
 

--- a/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/ArtistAlleyModeration.razor
@@ -3,7 +3,7 @@
 @using Eurofurence.App.Backoffice.Services
 @using Eurofurence.App.Domain.Model.ArtistsAlley
 @using Microsoft.AspNetCore.Authorization
-@using Color = MudBlazor.Color
+@using Color=MudBlazor.Color
 
 @attribute [Authorize(Policy = "RequireArtistAlleyModerator")]
 
@@ -64,29 +64,11 @@ More data of the applicant shall be visble an extra dialog
             <CellTemplate>
                 <MudContainer MaxWidth="MaxWidth.Small">
                     <MudGrid Class="justify-center">
-                        <MudItem xs="12" Style="text-align: center;">
+                        <MudItem xs="6" Style="text-align: center;">
                             @switch (context2.Item?.State)
                             {
                                 case TableRegistrationRecord.RegistrationStateEnum.Pending:
-                                    <MudButtonGroup OverrideStyles="false" Vertical="true">
-                                        <MudButton Variant="Variant.Outlined" Color="Color.Success" StartIcon="@Icons.Material.Filled.CheckCircle" ref="appBtn"
-                                                   OnClick="args => TryChangeRegistrationStatus(context2.Item, false)">
-                                            Approve
-                                        </MudButton>
-                                        <MudButton Variant="Variant.Outlined" Color="Color.Warning" StartIcon="@Icons.Material.Filled.Cancel"
-                                                   OnClick="args => TryChangeRegistrationStatus(context2.Item, true)">
-                                            Reject
-                                        </MudButton>
-                                        @*Show the delete button only for admins*@
-                                        <AuthorizeView Policy="RequireArtistAlleyAdmin">
-                                            <Authorized>
-                                                <MudButton Variant="Variant.Outlined" Color="Color.Error" StartIcon="@Icons.Material.Filled.Delete"
-                                                           OnClick="args => DeleteRegistration(context2.Item)">
-                                                    Delete
-                                                </MudButton>
-                                            </Authorized>
-                                        </AuthorizeView>
-                                    </MudButtonGroup>
+                                    <MudAlert Severity="Severity.Info">Pending</MudAlert>
                                     break;
                                 case TableRegistrationRecord.RegistrationStateEnum.Accepted:
                                     <MudAlert Severity="Severity.Success">Accepted</MudAlert>
@@ -103,6 +85,31 @@ More data of the applicant shall be visble an extra dialog
                                 Details
                             </MudButton>
                         </MudItem>
+                        <MudItem xs="6">
+                            <MudButtonGroup OverrideStyles="false" Vertical="true">
+                                @if (context2.Item.State == TableRegistrationRecord.RegistrationStateEnum.Pending)
+                                {
+
+                                    <MudButton Variant="Variant.Outlined" Color="Color.Success" StartIcon="@Icons.Material.Filled.CheckCircle" ref="appBtn"
+                                               OnClick="args => TryChangeRegistrationStatus(context2.Item, false)">
+                                        Approve
+                                    </MudButton>
+                                    <MudButton Variant="Variant.Outlined" Color="Color.Warning" StartIcon="@Icons.Material.Filled.Cancel"
+                                               OnClick="args => TryChangeRegistrationStatus(context2.Item, true)">
+                                        Reject
+                                    </MudButton>
+                                }
+                                @*Show the delete button only for admins*@
+                                <AuthorizeView Policy="RequireArtistAlleyAdmin">
+                                    <Authorized>
+                                        <MudButton Variant="Variant.Outlined" Color="Color.Error" StartIcon="@Icons.Material.Filled.Delete"
+                                                   OnClick="args => DeleteRegistration(context2.Item)">
+                                            Delete
+                                        </MudButton>
+                                    </Authorized>
+                                </AuthorizeView>
+                            </MudButtonGroup>
+                        </MudItem>
                     </MudGrid>
                 </MudContainer>
             </CellTemplate>
@@ -116,6 +123,7 @@ More data of the applicant shall be visble an extra dialog
 @code {
 
     #region Attributes
+
     /// <summary>
     /// Instance of the data grid
     /// </summary>
@@ -170,10 +178,18 @@ More data of the applicant shall be visble an extra dialog
     {
         DialogParameters<ConfirmDialog> dialog = new()
         {
-            { x => x.ContentText, $"Are you sure you want to delete this application?" },
-            { x => x.ActionButtonText, "Confirm" }
+            {
+                x => x.ContentText, $"Are you sure you want to delete this application?"
+            },
+            {
+                x => x.ActionButtonText, "Confirm"
+            }
         };
-        var options = new DialogOptions() { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
+        var options = new DialogOptions()
+        {
+            CloseButton = true,
+            MaxWidth = MaxWidth.ExtraSmall
+        };
         IDialogReference dialogRef = await DialogService.ShowAsync<ConfirmDialog>("Confirm", dialog, options);
         DialogResult? result = await dialogRef.Result;
 
@@ -195,10 +211,18 @@ More data of the applicant shall be visble an extra dialog
     {
         DialogParameters<ConfirmDialog> dialog = new()
         {
-            { x => x.ContentText, $"Are you sure you want to {(reject ? "reject" : "approve")} this application?" },
-            { x => x.ActionButtonText, "Confirm" }
+            {
+                x => x.ContentText, $"Are you sure you want to {(reject ? "reject" : "approve")} this application?"
+            },
+            {
+                x => x.ActionButtonText, "Confirm"
+            }
         };
-        var options = new DialogOptions { CloseButton = true, MaxWidth = MaxWidth.ExtraSmall };
+        var options = new DialogOptions
+        {
+            CloseButton = true,
+            MaxWidth = MaxWidth.ExtraSmall
+        };
         IDialogReference dialogRef = await DialogService.ShowAsync<ConfirmDialog>("Confirm", dialog, options);
         DialogResult? result = await dialogRef.Result;
 
@@ -219,10 +243,17 @@ More data of the applicant shall be visble an extra dialog
     {
         var parameters = new DialogParameters<ArtistAlleyApplicationDialog>()
         {
-            { x => x.Record, contextItem }
+            {
+                x => x.Record, contextItem
+            }
         };
 
-        var options = new DialogOptions { MaxWidth = MaxWidth.Large, FullWidth = true, CloseButton = true };
+        var options = new DialogOptions
+        {
+            MaxWidth = MaxWidth.Large,
+            FullWidth = true,
+            CloseButton = true
+        };
 
         var dialog = await DialogService.ShowAsync<ArtistAlleyApplicationDialog>("Application Details", parameters, options);
 

--- a/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
@@ -59,7 +59,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <returns>All table registrations.</returns>
         [ProducesResponseType(typeof(string), 404)]
         [ProducesResponseType(typeof(IEnumerable<TableRegistrationRecord>), 200)]
-        [Authorize(Roles = "Admin")]
+        [Authorize(Roles = "Admin, ArtistAlleyModerator, ArtistAlleyAdmin")]
         [HttpGet]
         public IEnumerable<TableRegistrationRecord> GetTableRegistrationsAsync()
         {
@@ -72,7 +72,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <param name="id">id of the requested entity</param>
         [ProducesResponseType(typeof(string), 404)]
         [ProducesResponseType(typeof(TableRegistrationRecord), 200)]
-        [Authorize(Roles = "Admin")]
+        [Authorize(Roles = "Admin, ArtistAlleyModerator, ArtistAlleyAdmin")]
         [HttpGet("{id}")]
         public async Task<TableRegistrationRecord> GetTableRegistrationAsync(
             [EnsureNotNull][FromRoute] Guid id


### PR DESCRIPTION
Artist alley applications can now also be deleted, even if they are already approved or rejected.

I've also fixed an authorization problem in the ArtistAlleyController, in which only admins could retrieve table registrations and change their status