### PR TITLE
fix(announcement): POST required Id and LastChangeDateTimeUtc

### DIFF
--- a/src/Eurofurence.App.Domain.Model/Announcements/AnnouncementRequest.cs
+++ b/src/Eurofurence.App.Domain.Model/Announcements/AnnouncementRequest.cs
@@ -1,34 +1,12 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
-using Eurofurence.App.Domain.Model.Images;
 
 namespace Eurofurence.App.Domain.Model.Announcements
 {
     [DataContract]
-    public class AnnouncementRecord : EntityBase
+    public class AnnouncementRequest
     {
-        /// <summary>
-        /// When does this announcement start to be valid?
-        /// </summary>
-        [DataMember]
-        [Required]
-        public DateTime ValidFromDateTimeUtc { get; set; }
-
-        /// <summary>
-        /// Until when will the announcement be valid?
-        /// </summary>
-        [DataMember]
-        [Required]
-        public DateTime ValidUntilDateTimeUtc { get; set; }
-
-        /// <summary>
-        /// Reference provided by JSON ingested in <c>UpdateAnnouncementsJob</c>.
-        /// </summary>
-        [JsonIgnore]
-        public string ExternalReference { get; set; }
-
         /// <summary>
         /// Type of announcement:
         /// <list type="bullet">
@@ -80,12 +58,9 @@ namespace Eurofurence.App.Domain.Model.Announcements
         public string Content { get; set; }
 
         /// <summary>
-        /// ID of an image uploaded via the POST endpoint for images.
+        /// ID of an image to be displayed with the announcement, uploaded via the POST endpoint for images.
         /// </summary>
         [DataMember]
         public Guid? ImageId { get; set; }
-
-        [JsonIgnore]
-        public ImageRecord Image { get; set; }
     }
 }

--- a/src/Eurofurence.App.Server.Web/Controllers/AnnouncementsController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/AnnouncementsController.cs
@@ -56,7 +56,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <returns></returns>
         [HttpDelete("{id}")]
         [Authorize(Roles = "Admin")]
-        [ProducesResponseType(200)]
+        [ProducesResponseType(204)]
         [ProducesResponseType(typeof(string), 404)]
         public async Task<ActionResult> DeleteAnnouncementAsync([FromRoute] Guid id)
         {
@@ -65,7 +65,7 @@ namespace Eurofurence.App.Server.Web.Controllers
             await _announcementService.DeleteOneAsync(id);
             await _pushNotificationChannelManager.PushSyncRequestAsync();
 
-            return Ok();
+            return NoContent();
         }
 
 
@@ -129,12 +129,13 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <returns></returns>
         [HttpDelete]
         [Authorize(Roles = "Admin")]
+        [ProducesResponseType(204)]
         public async Task<ActionResult> ClearAnnouncementAsync()
         {
             await _announcementService.DeleteAllAsync();
             await _pushNotificationChannelManager.PushSyncRequestAsync();
 
-            return Ok();
+            return NoContent();
         }
     }
 }


### PR DESCRIPTION
* POST endpoint required both `Id` and `LastChangeDateTimeUtc` to be set in the request instead of being set server-side.
* Improve error handling to avoid 500 errors with stacktraces.