### PR TITLE
Revert "build(deps): bump Telegram.Bot and Microsoft.Extensions.Configuration.Binder"

### DIFF
--- a/src/Eurofurence.App.Server.Services/Eurofurence.App.Server.Services.csproj
+++ b/src/Eurofurence.App.Server.Services/Eurofurence.App.Server.Services.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.4" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="Telegram.Bot" Version="22.1.3" />
+    <PackageReference Include="Telegram.Bot" Version="19.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />


### PR DESCRIPTION
Reverts eurofurence/ef-app_backend-dotnet-core#255

I noticed issues with breaking changes in the new major releases.
We have to adjust our Telegram Bot integration code.