### PR TITLE
fix: docker build failed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG MYSQL_VERSION=10.11.8-MariaDB
 WORKDIR /app
 ENV NUGET_PACKAGES=/dotnet/packages
-
+# Disable husky in docker build
+ENV HUSKY=0
 # Allow results of `dotnet restore` to be cached if there are no changes to dependencies.
 COPY ./NuGet.config /app/NuGet.config
 RUN --mount=type=cache,target=/dotnet/packages \
     --mount=type=cache,target=/dotnet/global-packages \
     --mount=type=bind,source=./ef-app_backend-dotnet-core.sln,target=/app/ef-app_backend-dotnet-core.sln \
     --mount=type=bind,source=./src/Eurofurence.App.Common/Eurofurence.App.Common.csproj,target=/app/src/Eurofurence.App.Common/Eurofurence.App.Common.csproj \
-    --mount=type=bind,source=./src/Eurofurence.App.Tools.CliToolBox/Eurofurence.App.Tools.CliToolBox.csproj,target=/app/src/Eurofurence.App.Tools.CliToolBox/Eurofurence.App.Tools.CliToolBox.csproj \
     --mount=type=bind,source=./src/Eurofurence.App.Server.Services/Eurofurence.App.Server.Services.csproj,target=/app/src/Eurofurence.App.Server.Services/Eurofurence.App.Server.Services.csproj \
     --mount=type=bind,source=./src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj,target=/app/src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj \
     --mount=type=bind,source=./src/Eurofurence.App.Backoffice/Eurofurence.App.Backoffice.csproj,target=/app/src/Eurofurence.App.Backoffice/Eurofurence.App.Backoffice.csproj \

--- a/Dockerfile-backoffice
+++ b/Dockerfile-backoffice
@@ -1,13 +1,12 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app
-
+ENV HUSKY=0
 # Allow results of `dotnet restore` to be cached if there are no changes to dependencies.
 COPY ./NuGet.config /app/NuGet.config
 RUN --mount=type=cache,target=/dotnet/packages \
     --mount=type=cache,target=/dotnet/global-packages \
     --mount=type=bind,source=./ef-app_backend-dotnet-core.sln,target=/app/ef-app_backend-dotnet-core.sln \
     --mount=type=bind,source=./src/Eurofurence.App.Common/Eurofurence.App.Common.csproj,target=/app/src/Eurofurence.App.Common/Eurofurence.App.Common.csproj \
-    --mount=type=bind,source=./src/Eurofurence.App.Tools.CliToolBox/Eurofurence.App.Tools.CliToolBox.csproj,target=/app/src/Eurofurence.App.Tools.CliToolBox/Eurofurence.App.Tools.CliToolBox.csproj \
     --mount=type=bind,source=./src/Eurofurence.App.Server.Services/Eurofurence.App.Server.Services.csproj,target=/app/src/Eurofurence.App.Server.Services/Eurofurence.App.Server.Services.csproj \
     --mount=type=bind,source=./src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj,target=/app/src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj \
     --mount=type=bind,source=./src/Eurofurence.App.Backoffice/Eurofurence.App.Backoffice.csproj,target=/app/src/Eurofurence.App.Backoffice/Eurofurence.App.Backoffice.csproj \

--- a/justfile
+++ b/justfile
@@ -49,14 +49,9 @@ build $MYSQL_VERSION=env_var('EF_MOBILE_APP_MYSQL_VERSION'): (_create_if_not_exi
 	dotnet restore
 	dotnet build src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj --configuration Release
 	dotnet build src/Eurofurence.App.Backoffice/Eurofurence.App.Backoffice.csproj --configuration Release
-	dotnet publish src/Eurofurence.App.Tools.CliToolBox/Eurofurence.App.Tools.CliToolBox.csproj --output "$(pwd)/artifacts/cli" --configuration Release
 	dotnet ef migrations bundle -o "$(pwd)/artifacts/db-migration-bundle" -p src/Eurofurence.App.Server.Web
 	dotnet publish src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj --output "$(pwd)/artifacts/backend" --configuration Release
 	dotnet publish src/Eurofurence.App.Backoffice/Eurofurence.App.Backoffice.csproj --output "$(pwd)/artifacts/backoffice" --configuration Release
-
-# Build just CLI tools as single, self-contained executable
-build-cli:
-	dotnet publish src/Eurofurence.App.Tools.CliToolBox/Eurofurence.App.Tools.CliToolBox.csproj --output "$(pwd)/artifacts" --configuration Release --sc -p:PublishSingleFile=true -p:DebugType=None -p:DebugSymbols=false -p:GenerateDocumentationFile=false
 
 # Build release container for service using spec from docker-compose.yml and refresh service if stack is running
 containerize SERVICE="" *ARGS="":

--- a/src/Eurofurence.App.Server.Services/Eurofurence.App.Server.Services.csproj
+++ b/src/Eurofurence.App.Server.Services/Eurofurence.App.Server.Services.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.2.1" />
     <PackageReference Include="Minio" Version="6.0.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />


### PR DESCRIPTION
The docker build has been failing recently.
Probably due to several PRs (#242 #250,and #265) - some of which I created myself, to my shame.

+ The Clitoolbox was still referenced at some places
+ Husky.Net wasn't disabled in docker properly.
+ We've updated to dotnet 9 too early, so I rolled back to version 8, since we don't target version 9 yet.
Correct me if I'm wrong here @Metawolve, but AFAIK, you can only compile a dotnet project with the same version of dotnet installed, right?
+ Transitive dependency caused a compile error and I had to upgrade it (no breaking changes from what I'm seeing).