### PR TITLE
feat(#286): add new API endpoint for deleting the user's own artist alley registration

### DIFF
--- a/src/Eurofurence.App.Server.Services/Abstractions/ArtistsAlley/ITableRegistrationService.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/ArtistsAlley/ITableRegistrationService.cs
@@ -16,6 +16,14 @@ namespace Eurofurence.App.Server.Services.Abstractions.ArtistsAlley
         IQueryable<TableRegistrationRecord> GetRegistrations(TableRegistrationRecord.RegistrationStateEnum? state);
         Task<TableRegistrationRecord> GetLatestRegistrationByUidAsync(string uid);
 
+        /// <summary>
+        /// Deletes the latest registration of a given user by their ID (<paramref name="uid"/>)
+        /// </summary>
+        /// <param name="uid">The ID of the user whose registration should be deleted</param>
+        /// <exception cref="ArgumentException">Can be thrown when no registration can be found under the users <paramref name="uid"/></exception>
+        /// <returns></returns>
+        Task DeleteLatestRegistrationByUidAsync(string uid);
+
         Task ApproveByIdAsync(Guid id, string operatorUid);
         Task RejectByIdAsync(Guid id, string operatorUid);
     }

--- a/src/Eurofurence.App.Server.Services/ArtistsAlley/TableRegistrationService.cs
+++ b/src/Eurofurence.App.Server.Services/ArtistsAlley/TableRegistrationService.cs
@@ -249,5 +249,19 @@ namespace Eurofurence.App.Server.Services.ArtistsAlley
 
             return request;
         }
+
+        public async Task DeleteLatestRegistrationByUidAsync(string userUid)
+        {
+            TableRegistrationRecord tableRegistrationRecord = await _appDbContext.TableRegistrations
+                .OrderByDescending(a => a.CreatedDateTimeUtc)
+                .FirstOrDefaultAsync(a => a.OwnerUid == userUid);
+
+            if (tableRegistrationRecord == null)
+            {
+                throw new ArgumentException("User has not been registered yet.");
+            }
+
+            await DeleteOneAsync(tableRegistrationRecord.Id);
+        }
     }
 }

--- a/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/ArtistsAlleyController.cs
@@ -89,6 +89,28 @@ namespace Eurofurence.App.Server.Web.Controllers
         }
 
         /// <summary>
+        /// Performs a checkout of the user out of the artist alley.
+        /// This will delete the registration of the current authenticated user.
+        /// </summary>
+        /// <returns></returns>
+        [Authorize(Roles = "AttendeeCheckedIn")]
+        [HttpDelete("TableRegistration/:my-latest")]
+        [ProducesResponseType(404)]
+        [ProducesResponseType(204)]
+        public async Task<ActionResult> ArtistAlleyCheckoutAsync()
+        {
+            try
+            {
+                await _tableRegistrationService.DeleteLatestRegistrationByUidAsync(User.GetSubject());
+            }
+            catch (ArgumentException)
+            {
+                return NotFound("User has not been registered yet.");
+            }
+            return NoContent();
+        }
+
+        /// <summary>
         ///     Submits a new table registration for review in the name of the currently signed in user.
         /// </summary>
         /// <param name="request">details of the table registration</param>


### PR DESCRIPTION
Closes: #286 

This PR adds a new API endpoint for deleting the currently logged-in user's artist alley registration.
