### PR TITLE
318 efnav integration

### DIFF
--- a/src/Eurofurence.App.Domain.Model/Dealers/DealerResponse.cs
+++ b/src/Eurofurence.App.Domain.Model/Dealers/DealerResponse.cs
@@ -144,6 +144,12 @@ public class DealerResponse : ResponseBase
     public Dictionary<string, string[]>? Keywords { get; set; }
 
     /// <summary>
+    /// Deep link to the location of this dealer in the map system (e.g. EFNav)
+    /// </summary>
+    [DataMember]
+    public string MapLink { get; set; }
+
+    /// <summary>
     /// Nickname number (as on badge) of the attendee that acts on behalf/represents this dealer.
     /// </summary>
     // TODO: Remove entirely for EF29

--- a/src/Eurofurence.App.Domain.Model/Events/EventConferenceRoomResponse.cs
+++ b/src/Eurofurence.App.Domain.Model/Events/EventConferenceRoomResponse.cs
@@ -7,4 +7,10 @@ public class EventConferenceRoomResponse : ResponseBase
 {
     [DataMember]
     public string Name { get; set; }
+
+    /// <summary>
+    /// Deep link to the location of this event room in the map system (e.g. EFNav)
+    /// </summary>
+    [DataMember]
+    public string MapLink { get; set; }
 }

--- a/src/Eurofurence.App.Server.Services/Abstractions/Dealers/IDealerService.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/Dealers/IDealerService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Eurofurence.App.Domain.Model.Dealers;
 
@@ -9,5 +10,7 @@ namespace Eurofurence.App.Server.Services.Abstractions.Dealers
         IPatchOperationProcessor<DealerRecord>
     {
         public Task RunImportAsync(CancellationToken cancellationToken = default);
+
+        public string GetMapLink(Guid id);
     }
 }

--- a/src/Eurofurence.App.Server.Services/Abstractions/Events/IEventConferenceRoomService.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/Events/IEventConferenceRoomService.cs
@@ -1,9 +1,12 @@
 ﻿using Eurofurence.App.Domain.Model.Events;
+using System;
 
 namespace Eurofurence.App.Server.Services.Abstractions.Events
 {
     public interface IEventConferenceRoomService :
         IEntityServiceOperations<EventConferenceRoomRecord, EventConferenceRoomResponse>,
         IPatchOperationProcessor<EventConferenceRoomRecord>
-    { }
+    {
+        public string GetMapLink(Guid id);
+    }
 }

--- a/src/Eurofurence.App.Server.Services/Abstractions/Maps/MapOptions.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/Maps/MapOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace Eurofurence.App.Server.Services.Abstractions.Maps
+{
+    public class MapOptions
+    {
+        public string UrlTemplate { get; init; }
+    }
+}

--- a/src/Eurofurence.App.Server.Services/ArtistsAlley/TableRegistrationService.cs
+++ b/src/Eurofurence.App.Server.Services/ArtistsAlley/TableRegistrationService.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Eurofurence.App.Common.ExtensionMethods;
 using Eurofurence.App.Domain.Model.ArtistsAlley;
 using Eurofurence.App.Domain.Model.Communication;
-using Eurofurence.App.Domain.Model.Images;
 using Eurofurence.App.Infrastructure.EntityFramework;
 using Eurofurence.App.Server.Services.Abstractions;
 using Eurofurence.App.Server.Services.Abstractions.ArtistsAlley;

--- a/src/Eurofurence.App.Server.Services/Events/EventConferenceRoomService.cs
+++ b/src/Eurofurence.App.Server.Services/Events/EventConferenceRoomService.cs
@@ -6,7 +6,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using System;
 using System.Threading;
+using Eurofurence.App.Server.Services.Abstractions.Maps;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Eurofurence.App.Domain.Model.Sync;
+using Eurofurence.App.Server.Web.Controllers.Transformers;
 
 namespace Eurofurence.App.Server.Services.Events
 {
@@ -14,14 +18,16 @@ namespace Eurofurence.App.Server.Services.Events
         IEventConferenceRoomService
     {
         private readonly AppDbContext _appDbContext;
+        private readonly MapOptions _mapOptions;
 
         public EventConferenceRoomService(
             AppDbContext appDbContext,
-            IStorageServiceFactory storageServiceFactory
-        )
+            IStorageServiceFactory storageServiceFactory,
+            IOptions<MapOptions> mapOptions)
             : base(appDbContext, storageServiceFactory)
         {
             _appDbContext = appDbContext;
+            _mapOptions = mapOptions.Value;
         }
 
         public override async Task<EventConferenceRoomRecord> FindOneAsync(
@@ -39,6 +45,64 @@ namespace Eurofurence.App.Server.Services.Events
             return _appDbContext.EventConferenceRooms
                 .Include(eventConferenceRoom => eventConferenceRoom.Events)
                 .AsNoTracking();
+        }
+
+        public string GetMapLink(Guid id)
+        {
+            return _mapOptions.UrlTemplate.Replace("{id}", id.ToString());
+        }
+
+        public override async Task<DeltaResponse<EventConferenceRoomResponse>> GetDeltaResponseAsync(
+            DateTime? minLastDateTimeChangedUtc = null,
+            CancellationToken cancellationToken = default)
+        {
+            var storageInfo = await GetStorageInfoAsync(cancellationToken);
+            var response = new DeltaResponse<EventConferenceRoomResponse>
+            {
+                StorageDeltaStartChangeDateTimeUtc = storageInfo.DeltaStartDateTimeUtc,
+                StorageLastChangeDateTimeUtc = storageInfo.LastChangeDateTimeUtc
+            };
+
+            if (!minLastDateTimeChangedUtc.HasValue || minLastDateTimeChangedUtc < storageInfo.DeltaStartDateTimeUtc)
+            {
+                response.RemoveAllBeforeInsert = true;
+                response.DeletedEntities = Array.Empty<Guid>();
+
+                var changedEntities = await
+                    _appDbContext.EventConferenceRooms
+                        .Where(entity => entity.IsDeleted == 0)
+                        .Select(x => x.Transform())
+                        .ToListAsync(cancellationToken);
+
+                changedEntities.ForEach(x => x.MapLink = GetMapLink(x.Id));
+
+                response.ChangedEntities = changedEntities
+                        .ToArray();
+            }
+            else
+            {
+                response.RemoveAllBeforeInsert = false;
+
+                var entities = _appDbContext.EventConferenceRooms.IgnoreQueryFilters()
+                    .Where(entity => entity.LastChangeDateTimeUtc > minLastDateTimeChangedUtc);
+
+                var changedEntities = await entities
+                    .Where(a => a.IsDeleted == 0)
+                    .Select(x => x.Transform())
+                    .ToListAsync(cancellationToken);
+
+                changedEntities.ForEach(x => x.MapLink = GetMapLink(x.Id));
+
+                response.ChangedEntities = changedEntities
+                    .ToArray();
+
+                response.DeletedEntities = await entities
+                    .Where(a => a.IsDeleted == 1)
+                    .Select(a => a.Id)
+                    .ToArrayAsync(cancellationToken);
+            }
+
+            return response;
         }
     }
 }

--- a/src/Eurofurence.App.Server.Web/Controllers/DealersController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/DealersController.cs
@@ -9,8 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Eurofurence.App.Server.Web.Controllers.Transformers;
-using MapsterMapper;
-using Eurofurence.App.Server.Web.Controllers.Transformers;
+using Microsoft.EntityFrameworkCore;
 
 namespace Eurofurence.App.Server.Web.Controllers
 {
@@ -35,9 +34,11 @@ namespace Eurofurence.App.Server.Web.Controllers
         [HttpGet]
         [ProducesResponseType(typeof(string), 404)]
         [ProducesResponseType(typeof(IEnumerable<DealerResponse>), 200)]
-        public IQueryable<DealerResponse> GetDealerEntriesAsync()
+        public async Task<IEnumerable<DealerResponse>> GetDealerEntriesAsync()
         {
-            return _dealerService.FindAll().Select(x => x.Transform());
+            var result = await _dealerService.FindAll().Select(x => x.Transform()).ToListAsync();
+            result.ForEach(r => r.MapLink = _dealerService.GetMapLink(r.Id));
+            return result;
         }
 
         /// <summary>
@@ -49,7 +50,9 @@ namespace Eurofurence.App.Server.Web.Controllers
         [ProducesResponseType(typeof(DealerResponse), 200)]
         public async Task<DealerResponse> GetDealerAsync([FromRoute] Guid id)
         {
-            return (await _dealerService.FindOneAsync(id)).Transient404(HttpContext).Transform();
+            var result = (await _dealerService.FindOneAsync(id)).Transient404(HttpContext).Transform();
+            result.MapLink = _dealerService.GetMapLink(result.Id);
+            return result;
         }
 
 

--- a/src/Eurofurence.App.Server.Web/Controllers/EventConferenceRoomsController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/EventConferenceRoomsController.cs
@@ -7,6 +7,7 @@ using Eurofurence.App.Server.Services.Abstractions.Events;
 using Eurofurence.App.Server.Web.Controllers.Transformers;
 using Eurofurence.App.Server.Web.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace Eurofurence.App.Server.Web.Controllers
 {
@@ -27,9 +28,11 @@ namespace Eurofurence.App.Server.Web.Controllers
         [HttpGet]
         [ProducesResponseType(typeof(string), 404)]
         [ProducesResponseType(typeof(IEnumerable<EventConferenceRoomResponse>), 200)]
-        public IQueryable<EventConferenceRoomResponse> GetEventsAsync()
+        public async Task<IEnumerable<EventConferenceRoomResponse>> GetEventsAsync()
         {
-            return _eventConferenceRoomService.FindAll().Select(x => x.Transform());
+            var result = await _eventConferenceRoomService.FindAll().Select(x => x.Transform()).ToListAsync();
+            result.ForEach(r => r.MapLink = _eventConferenceRoomService.GetMapLink(r.Id));
+            return result;
         }
 
         /// <summary>
@@ -41,7 +44,9 @@ namespace Eurofurence.App.Server.Web.Controllers
         [ProducesResponseType(typeof(EventConferenceRoomResponse), 200)]
         public async Task<EventConferenceRoomResponse> GetEventAsync([FromRoute] Guid id)
         {
-            return (await _eventConferenceRoomService.FindOneAsync(id)).Transient404(HttpContext).Transform();
+            var result = (await _eventConferenceRoomService.FindOneAsync(id)).Transient404(HttpContext).Transform();
+            result.MapLink = _eventConferenceRoomService.GetMapLink(result.Id);
+            return result;
         }
     }
 }

--- a/src/Eurofurence.App.Server.Web/Program.cs
+++ b/src/Eurofurence.App.Server.Web/Program.cs
@@ -29,6 +29,7 @@ using Serilog.Context;
 using Swashbuckle.AspNetCore.SwaggerUI;
 using Eurofurence.App.Server.Services.Abstractions.ArtistsAlley;
 using Eurofurence.App.Server.Services.Abstractions.Identity;
+using Eurofurence.App.Server.Services.Abstractions.Maps;
 using Eurofurence.App.Server.Services.Abstractions.MinIO;
 using Eurofurence.App.Server.Services.Abstractions.PushNotifications;
 using Eurofurence.App.Server.Services.Abstractions.QrCode;
@@ -67,6 +68,7 @@ namespace Eurofurence.App.Server.Web
             builder.Services.Configure<DealerOptions>(builder.Configuration.GetSection("Dealers"));
             builder.Services.Configure<AnnouncementOptions>(builder.Configuration.GetSection("Announcements"));
             builder.Services.Configure<EventOptions>(builder.Configuration.GetSection("Events"));
+            builder.Services.Configure<MapOptions>(builder.Configuration.GetSection("Maps"));
             builder.Services.Configure<IdentityOptions>(builder.Configuration.GetSection("Identity"));
             builder.Services.Configure<AuthorizationOptions>(builder.Configuration.GetSection("Authorization"));
             builder.Services.Configure<ForwardedHeadersOptions>(options =>

--- a/src/Eurofurence.App.Server.Web/appsettings.sample.json
+++ b/src/Eurofurence.App.Server.Web/appsettings.sample.json
@@ -155,5 +155,8 @@
       "GetiPhoneApp": "",
       "AATablereg": ""
     }
+  },
+  "Maps": {
+    "UrlTemplate": "https://nav.eurofurence.org/l/uuid-{id}/"
   }
 }


### PR DESCRIPTION
Added property "MapLink" to dealers responses and event conference room responses, which is computed at runtime for all affected endpionts including the sync endpoint.

The template for the map link is configured via the appsettings (added to appsettings.sample.json):

```
"Maps": {
  "UrlTemplate": "https://nav.eurofurence.org/l/uuid-{id}/"
}
```