### PR TITLE
fix(#329): sending an artist alley table registration request now results in an update of the existing data

### DIFF
--- a/src/Eurofurence.App.Backoffice/Eurofurence.App.Backoffice.csproj
+++ b/src/Eurofurence.App.Backoffice/Eurofurence.App.Backoffice.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Markdig" Version="0.41.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.15" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.15" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.5" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.15" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.5" />

--- a/src/Eurofurence.App.Server.Services/Abstractions/ArtistsAlley/ITableRegistrationService.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/ArtistsAlley/ITableRegistrationService.cs
@@ -13,7 +13,20 @@ namespace Eurofurence.App.Server.Services.Abstractions.ArtistsAlley
         IPatchOperationProcessor<TableRegistrationRecord>
     {
         Task RegisterTableAsync(ClaimsPrincipal user, TableRegistrationRequest request, Stream imageStream);
+
+        /// <summary>
+        /// Updates an existing table registration identified by the specified ID.
+        ///
+        /// This will set the status of the registration to back to "Pending".
+        /// </summary>
+        /// <param name="id">The unique identifier of the table registration to update</param>
+        /// <param name="request">The request object containing updated registration details</param>
+        /// <param name="imageStream">Stream containing the new image data for the table registration</param>
+        /// <returns>A task representing the asynchronous update operation</returns>
+        Task UpdateTableAsync(ClaimsPrincipal user, Guid id, TableRegistrationRequest request, Stream imageStream);
+
         IQueryable<TableRegistrationRecord> GetRegistrations(TableRegistrationRecord.RegistrationStateEnum? state);
+
         Task<TableRegistrationRecord> GetLatestRegistrationByUidAsync(string uid);
 
         /// <summary>
@@ -25,6 +38,7 @@ namespace Eurofurence.App.Server.Services.Abstractions.ArtistsAlley
         Task DeleteLatestRegistrationByUidAsync(string uid);
 
         Task ApproveByIdAsync(Guid id, string operatorUid);
+
         Task RejectByIdAsync(Guid id, string operatorUid);
     }
 }

--- a/src/Eurofurence.App.Server.Services/Abstractions/Telegram/ITelegramMessageSender.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/Telegram/ITelegramMessageSender.cs
@@ -9,9 +9,9 @@ namespace Eurofurence.App.Server.Services.Abstractions.Telegram
     {
         event Func<string, string, Task> OnSendMarkdownMessageToChatAsync;
         event Func<string, Stream, string, Task> OnSendImageToChatAsync;
-        event Func<string, TableRegistrationRecord, Task> OnTableRegistrationAsync;
+        event Func<string, TableRegistrationRecord, bool, Task> OnTableRegistrationAsync;
         Task SendMarkdownMessageToChatAsync(string chatId, string message);
         Task SendImageToChatAsync(string chatId, Stream image, string message = "");
-        Task SendTableRegistrationAsync(string chatId, TableRegistrationRecord record);
+        Task SendTableRegistrationAsync(string chatId, TableRegistrationRecord record, bool updated);
     }
 }

--- a/src/Eurofurence.App.Server.Services/ArtistsAlley/TableRegistrationService.cs
+++ b/src/Eurofurence.App.Server.Services/ArtistsAlley/TableRegistrationService.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Eurofurence.App.Common.ExtensionMethods;
 using Eurofurence.App.Domain.Model.ArtistsAlley;
 using Eurofurence.App.Domain.Model.Communication;
+using Eurofurence.App.Domain.Model.Images;
 using Eurofurence.App.Infrastructure.EntityFramework;
 using Eurofurence.App.Server.Services.Abstractions;
 using Eurofurence.App.Server.Services.Abstractions.ArtistsAlley;
@@ -17,6 +18,7 @@ using Eurofurence.App.Server.Services.Abstractions.Images;
 using Eurofurence.App.Server.Services.Abstractions.Sanitization;
 using Eurofurence.App.Server.Services.Abstractions.Security;
 using Eurofurence.App.Server.Services.Abstractions.Telegram;
+using Eurofurence.App.Server.Web.Controllers.Transformers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
@@ -53,6 +55,7 @@ namespace Eurofurence.App.Server.Services.ArtistsAlley
             _htmlSanitizer = htmlSanitizer;
         }
 
+
         public IQueryable<TableRegistrationRecord> GetRegistrations(TableRegistrationRecord.RegistrationStateEnum? state)
         {
             var records = _appDbContext.TableRegistrations
@@ -71,7 +74,7 @@ namespace Eurofurence.App.Server.Services.ArtistsAlley
                 .FirstOrDefaultAsync(tr => tr.Id == id, cancellationToken);
         }
 
-        public async Task RegisterTableAsync(ClaimsPrincipal user, TableRegistrationRequest request, Stream imageStream)
+        private void ValidateRegistrationRequest(TableRegistrationRequest request, Stream imageStream)
         {
             if (!string.IsNullOrWhiteSpace(request.WebsiteUrl))
                 if (_uriSanitizer.Sanitize(request.WebsiteUrl) is string sanitizedUrl and not null)
@@ -98,15 +101,44 @@ namespace Eurofurence.App.Server.Services.ArtistsAlley
             {
                 throw new ArgumentException("Registrations must include an image.");
             }
+        }
+
+        public async Task UpdateTableAsync(ClaimsPrincipal user, Guid id, TableRegistrationRequest request, Stream imageStream)
+        {
+            ValidateRegistrationRequest(request, imageStream);
+            string subject = user.GetSubject();
+
+            TableRegistrationRecord record = await _appDbContext.TableRegistrations.FirstOrDefaultAsync(tr => tr.Id == id);
+
+            if (record == null)
+            {
+                throw new ArgumentException($"No existing approved table registration found with ID {id}.");
+            }
+
+            record.Merge(request);
+
+            ImageRecord image = await _imageService.InsertImageAsync($"artistalley:{subject}:{user.GetRegSysIds().FirstOrDefault("none")}", imageStream, true, 1500, 1500);
+            record.ImageId = image.Id;
+
+            TableRegistrationRecord.StateChangeRecord stateChange = record.ChangeState(TableRegistrationRecord.RegistrationStateEnum.Pending, $"Data-Updated-By-Artist: {subject}");
+            _appDbContext.StateChangeRecord.Add(stateChange);
+
+            await _appDbContext.SaveChangesAsync();
+            await _telegramMessageSender.SendTableRegistrationAsync(_artistAlleyOptions.Telegram.AdminGroupChatId, record, true);
+        }
+
+        public async Task RegisterTableAsync(ClaimsPrincipal user, TableRegistrationRequest request, Stream imageStream)
+        {
+            ValidateRegistrationRequest(request, imageStream);
 
             var subject = user.GetSubject();
-            var activeRegistrations = await _appDbContext.TableRegistrations
+            var activePendingRegistrations = await _appDbContext.TableRegistrations
                 .Where(x =>
                     x.OwnerUid == subject &&
                     x.State == TableRegistrationRecord.RegistrationStateEnum.Pending)
                 .ToListAsync();
 
-            foreach (var registration in activeRegistrations)
+            foreach (var registration in activePendingRegistrations)
             {
                 if (registration.ImageId is { } imageId) await _imageService.DeleteOneAsync(imageId);
                 await DeleteOneAsync(registration.Id);
@@ -135,7 +167,8 @@ namespace Eurofurence.App.Server.Services.ArtistsAlley
             await _appDbContext.SaveChangesAsync();
             await _telegramMessageSender.SendTableRegistrationAsync(
                 _artistAlleyOptions.Telegram.AdminGroupChatId,
-                record
+                record,
+                false
             );
         }
 
@@ -167,7 +200,7 @@ namespace Eurofurence.App.Server.Services.ArtistsAlley
 
             await _privateMessageService.SendPrivateMessageAsync(sendPrivateMessageRequest);
 
-            await _appDbContext.SaveChangesAsync();
+
         }
 
         private async Task BroadcastAsync(TableRegistrationRecord record)

--- a/src/Eurofurence.App.Server.Services/ArtistsAlley/TableRegistrationService.cs
+++ b/src/Eurofurence.App.Server.Services/ArtistsAlley/TableRegistrationService.cs
@@ -146,7 +146,7 @@ namespace Eurofurence.App.Server.Services.ArtistsAlley
             var stateChange = record.ChangeState(TableRegistrationRecord.RegistrationStateEnum.Accepted, operatorUid);
             _appDbContext.StateChangeRecord.Add(stateChange);
             record.Touch();
-
+            await _appDbContext.SaveChangesAsync();
             await _telegramMessageSender.SendMarkdownMessageToChatAsync(
             _artistAlleyOptions.Telegram.AdminGroupChatId,
             $"*Approved:* {record.OwnerUsername.EscapeMarkdown()} ({record.OwnerUid.EscapeMarkdown()} / {record.Id})\n\nRegistration has been approved by *{operatorUid.RemoveMarkdown()}* and will be published on Telegram.");

--- a/src/Eurofurence.App.Server.Services/ArtistsAlley/TableRegistrationService.cs
+++ b/src/Eurofurence.App.Server.Services/ArtistsAlley/TableRegistrationService.cs
@@ -108,7 +108,9 @@ namespace Eurofurence.App.Server.Services.ArtistsAlley
             ValidateRegistrationRequest(request, imageStream);
             string subject = user.GetSubject();
 
-            TableRegistrationRecord record = await _appDbContext.TableRegistrations.FirstOrDefaultAsync(tr => tr.Id == id);
+            TableRegistrationRecord record = await _appDbContext
+                .TableRegistrations
+                .FirstOrDefaultAsync(tr => tr.Id == id);
 
             if (record == null)
             {
@@ -117,7 +119,8 @@ namespace Eurofurence.App.Server.Services.ArtistsAlley
 
             record.Merge(request);
 
-            ImageRecord image = await _imageService.InsertImageAsync($"artistalley:{subject}:{user.GetRegSysIds().FirstOrDefault("none")}", imageStream, true, 1500, 1500);
+            ImageRecord image = await _imageService
+                .InsertImageAsync($"artistalley:{subject}:{user.GetRegSysIds().FirstOrDefault("none")}", imageStream, true, 1500, 1500);
             record.ImageId = image.Id;
 
             TableRegistrationRecord.StateChangeRecord stateChange = record.ChangeState(TableRegistrationRecord.RegistrationStateEnum.Pending, $"Data-Updated-By-Artist: {subject}");
@@ -132,13 +135,13 @@ namespace Eurofurence.App.Server.Services.ArtistsAlley
             ValidateRegistrationRequest(request, imageStream);
 
             var subject = user.GetSubject();
-            var activePendingRegistrations = await _appDbContext.TableRegistrations
+            var activeRegistrations = await _appDbContext.TableRegistrations
                 .Where(x =>
                     x.OwnerUid == subject &&
                     x.State == TableRegistrationRecord.RegistrationStateEnum.Pending)
                 .ToListAsync();
 
-            foreach (var registration in activePendingRegistrations)
+            foreach (var registration in activeRegistrations)
             {
                 if (registration.ImageId is { } imageId) await _imageService.DeleteOneAsync(imageId);
                 await DeleteOneAsync(registration.Id);

--- a/src/Eurofurence.App.Server.Services/Telegram/TelegramMessageBroker.cs
+++ b/src/Eurofurence.App.Server.Services/Telegram/TelegramMessageBroker.cs
@@ -36,14 +36,14 @@ namespace Eurofurence.App.Server.Services.Telegram
             await Task.WhenAll(handlerTasks);
         }
 
-        public async Task SendTableRegistrationAsync(string chatId, TableRegistrationRecord record)
+        public async Task SendTableRegistrationAsync(string chatId, TableRegistrationRecord record, bool updated)
         {
             var invocationList = OnTableRegistrationAsync.GetInvocationList();
             var handlerTasks = new Task[invocationList.Length];
 
             for (var i = 0; i < invocationList.Length; i++)
             {
-                handlerTasks[i] = ((Func<string, TableRegistrationRecord, Task>)invocationList[i])(chatId, record);
+                handlerTasks[i] = ((Func<string, TableRegistrationRecord, bool, Task>)invocationList[i])(chatId, record, updated);
             }
 
             await Task.WhenAll(handlerTasks);
@@ -51,6 +51,6 @@ namespace Eurofurence.App.Server.Services.Telegram
 
         public event Func<string, string, Task> OnSendMarkdownMessageToChatAsync;
         public event Func<string, Stream, string, Task> OnSendImageToChatAsync;
-        public event Func<string, TableRegistrationRecord, Task> OnTableRegistrationAsync;
+        public event Func<string, TableRegistrationRecord, bool, Task> OnTableRegistrationAsync;
     }
 }

--- a/src/Eurofurence.App.Server.Web/Telegram/BotService.cs
+++ b/src/Eurofurence.App.Server.Web/Telegram/BotService.cs
@@ -117,11 +117,11 @@ public class BotService : BackgroundService, IUpdateHandler
         }
     }
 
-    private async Task OnTableRegistrationAsync(string chatId, TableRegistrationRecord record)
+    private async Task OnTableRegistrationAsync(string chatId, TableRegistrationRecord record, bool updated)
     {
         var message = await _client.SendTextMessageAsync(
             chatId,
-            $@"*New Request:* {record.OwnerUsername.EscapeMarkdown()} ({record.OwnerUid.EscapeMarkdown()})
+            $@"{(updated ? "*New Request:*" : "*Data updated:*")} {record.OwnerUsername.EscapeMarkdown()} ({record.OwnerUid.EscapeMarkdown()})
 
 *Display Name:* {record.DisplayName.EscapeMarkdown()}
 *Location:* {record.Location.RemoveMarkdown()}


### PR DESCRIPTION
Closes: #329 

Also Microsoft.AspNetCore.Components.WebAssembly.DevServer was downgraded to fix a bug when starting the backoffice without Docker.

Furthermore, when approving a table reg, the database changes are persisted **before** the telegram messages are sent.
This could also be moved to a separate issue/PR if you like.