### PR TITLE
Configure SentryBlazorOptions using appsettings.json

### DIFF
--- a/src/Eurofurence.App.Backoffice/Program.cs
+++ b/src/Eurofurence.App.Backoffice/Program.cs
@@ -10,6 +10,8 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
+builder.Services.Configure<SentryBlazorOptions>(builder.Configuration.GetSection("Sentry"));
+
 builder.UseSentry(options =>
 {
     options.SendDefaultPii = !builder.HostEnvironment.IsProduction();


### PR DESCRIPTION
Just. a small one line fix to make Sentry also configure from the `appsettings.json` in the Blazor/Backoffice Project, like it should.