### PR TITLE
fix(model): Mapster config for KnowledgeEntries

### DIFF
--- a/src/Eurofurence.App.Domain.Model/IAssemblyMarker.cs
+++ b/src/Eurofurence.App.Domain.Model/IAssemblyMarker.cs
@@ -1,5 +1,9 @@
 namespace Eurofurence.App.Domain.Model
 {
+    /// <summary>
+    /// Used by Eurofurence.App.Server.Web.Startup.ServiceCollectionExtensions to find the
+    /// type adapter configurations for Mapster in this assembly.
+    /// </summary>
     public interface IAssemblyMarker
     {
     }

--- a/src/Eurofurence.App.Domain.Model/IAssemblyMarker.cs
+++ b/src/Eurofurence.App.Domain.Model/IAssemblyMarker.cs
@@ -1,0 +1,6 @@
+namespace Eurofurence.App.Domain.Model
+{
+    public interface IAssemblyMarker
+    {
+    }
+}

--- a/src/Eurofurence.App.Domain.Model/Knowledge/KnowledgeEntryResponseRegister.cs
+++ b/src/Eurofurence.App.Domain.Model/Knowledge/KnowledgeEntryResponseRegister.cs
@@ -15,9 +15,7 @@ namespace Eurofurence.App.Server.Web.Mapper
         {
             config
                 .NewConfig<KnowledgeEntryRecord, KnowledgeEntryResponse>()
-                .Map(dest => dest.Id, src => src.Id)
-                .Map(dest => dest.ImageIds, src => src.Images.Select(ke => ke.Id))
-                .IgnoreNonMapped(true)
+                .Map(dest => dest.ImageIds, src => src.Images.Select(image => image.Id))
                 .PreserveReference(true);
 
             config

--- a/src/Eurofurence.App.Server.Services/Knowledge/KnowledgeEntryService.cs
+++ b/src/Eurofurence.App.Server.Services/Knowledge/KnowledgeEntryService.cs
@@ -35,11 +35,7 @@ namespace Eurofurence.App.Server.Services.Knowledge
             Guid id,
             CancellationToken cancellationToken = default)
         {
-            return await _appDbContext.KnowledgeEntries
-                .Include(m => m.Images)
-                .Include(m => m.Links)
-                .AsNoTracking()
-                .FirstOrDefaultAsync(entity => entity.Id == id, cancellationToken);
+            return await FindAll().FirstOrDefaultAsync(entity => entity.Id == id, cancellationToken);
         }
 
         public override IQueryable<KnowledgeEntryRecord> FindAll()
@@ -47,6 +43,7 @@ namespace Eurofurence.App.Server.Services.Knowledge
             return _appDbContext.KnowledgeEntries
                 .Include(m => m.Images)
                 .Include(m => m.Links)
+                .AsSplitQuery()
                 .AsNoTracking();
         }
 

--- a/src/Eurofurence.App.Server.Web/Startup/ServiceCollectionExtensions.cs
+++ b/src/Eurofurence.App.Server.Web/Startup/ServiceCollectionExtensions.cs
@@ -281,7 +281,7 @@ namespace Eurofurence.App.Server.Web.Startup
         {
             var typeAdapterConfig = TypeAdapterConfig.GlobalSettings;
             typeAdapterConfig.Default.PreserveReference(true);
-            typeAdapterConfig.Scan(typeof(Program).Assembly);
+            typeAdapterConfig.Scan(typeof(Eurofurence.App.Domain.Model.IAssemblyMarker).Assembly);
             services.AddSingleton(typeAdapterConfig);
             services.AddScoped<IMapper, ServiceMapper>();
 


### PR DESCRIPTION
* Fixes an issue where KnowledgeEntries were not correctly mapped to their respective response objects resulting in missing data on relations.
* Includes some DRY optimisations on the KnowledgeEntryService.