### PR TITLE
refactor: remove role requirement for Users/pass endpoint

### DIFF
--- a/src/Eurofurence.App.Server.Services/Abstractions/Identity/IIdentityService.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/Identity/IIdentityService.cs
@@ -24,6 +24,12 @@ namespace Eurofurence.App.Server.Services.Abstractions.Identity
         /// <returns>The svg image data</returns>
         public string GenerateUserMatrixCode(ClaimsIdentity identity);
 
-        public IEnumerable<string> GetRegistrations(ClaimsIdentity identity);
+        /// <summary>
+        /// Finds all registrations ids of the user.
+        /// Assumes, that <see cref="ReadRegSys"/> was called before (which it should in the authentication pipeline).
+        /// </summary>
+        /// <param name="identity">The <see cref="ClaimsIdentity"/> of the user.</param>
+        /// <returns>A sequence of all reg id of the user.</returns>
+        public IEnumerable<string> GetRegistrationsIds(ClaimsIdentity identity);
     }
 }

--- a/src/Eurofurence.App.Server.Services/Abstractions/Identity/IIdentityService.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/Identity/IIdentityService.cs
@@ -23,5 +23,7 @@ namespace Eurofurence.App.Server.Services.Abstractions.Identity
         /// <param name="identity">Users identity</param>
         /// <returns>The svg image data</returns>
         public string GenerateUserMatrixCode(ClaimsIdentity identity);
+
+        public IEnumerable<string> GetRegistrations(ClaimsIdentity identity);
     }
 }

--- a/src/Eurofurence.App.Server.Services/Identity/IdentityService.cs
+++ b/src/Eurofurence.App.Server.Services/Identity/IdentityService.cs
@@ -258,14 +258,14 @@ namespace Eurofurence.App.Server.Services.Identity
 
         public string GenerateUserMatrixCode(ClaimsIdentity identity)
         {
-            string userRegID = GetRegistrations(identity).FirstOrDefault() ?? string.Empty;
+            string userRegID = GetRegistrationsIds(identity).FirstOrDefault() ?? string.Empty;
             DmtxImageEncoder encoder = new DmtxImageEncoder();
             string img = encoder.EncodeSvgImage(userRegID);
 
             return img;
         }
 
-        public IEnumerable<string> GetRegistrations(ClaimsIdentity identity)
+        public IEnumerable<string> GetRegistrationsIds(ClaimsIdentity identity)
         {
             return identity.FindAll(UserRegistrationClaims.Id).Select(x => x.Value);
         }

--- a/src/Eurofurence.App.Server.Services/Identity/IdentityService.cs
+++ b/src/Eurofurence.App.Server.Services/Identity/IdentityService.cs
@@ -258,16 +258,16 @@ namespace Eurofurence.App.Server.Services.Identity
 
         public string GenerateUserMatrixCode(ClaimsIdentity identity)
         {
-            string userRegID = identity.FindFirst(UserRegistrationClaims.Id)?.Value;
-            if (userRegID == null)
-            {
-                // Should never happen, but just in case.
-                throw new InvalidOperationException("User Reg ID not found in claims.");
-            }
+            string userRegID = GetRegistrations(identity).FirstOrDefault() ?? string.Empty;
             DmtxImageEncoder encoder = new DmtxImageEncoder();
             string img = encoder.EncodeSvgImage(userRegID);
 
             return img;
+        }
+
+        public IEnumerable<string> GetRegistrations(ClaimsIdentity identity)
+        {
+            return identity.FindAll(UserRegistrationClaims.Id).Select(x => x.Value);
         }
 
         private async Task<UserRegistrationStatus> GetRegistrationStatus(string token, string id)

--- a/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
@@ -88,17 +88,37 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <summary>
         /// Returns a data matrix code for the current user.
         ///
-        /// The code is generated from the reg id of the user and returned as a svg.
+        /// The code is generated from the reg id of the user and returned as an image.
+        /// The image format can be specified by the Accept header.
         /// It should be the same as the code on the con badge.
         /// </summary>
         /// <returns>Data matrix code as svg.</returns>
         [HttpGet("pass")]
-        [Authorize(Roles = "AttendeeCheckedIn")]
-        public FileContentResult GetDataMatrixCode()
+        [ProducesResponseType(typeof(FileContentResult), 200)]
+        [ProducesResponseType(typeof(string), 404)]
+        public ActionResult GetDataMatrixCode()
         {
-            return File(Encoding.UTF8.GetBytes(_identityService.GenerateUserMatrixCode(User.Identity as ClaimsIdentity)), MediaTypeNames.Image.Svg, "matrix.svg");
+            if (User.Identity is ClaimsIdentity identity)
+            {
+                if (_identityService.GetRegistrations(identity).Any())
+                {
+                    try
+                    {
+                        string fileExtension = MimeTypes.MimeTypeMap.GetExtension(Request.Headers.Accept);
+                        return File(
+                            Encoding.UTF8.GetBytes(
+                                _identityService.GenerateUserMatrixCode(User.Identity as ClaimsIdentity)),
+                            Request.Headers.Accept,
+                            $"matrix{fileExtension}");
+                    }
+                    catch (Exception e) when (e is ArgumentException or FormatException)
+                    {
+                        return BadRequest("Accept header not recognized - unknown format");
+                    }
+                }
+            }
+            return NotFound();
         }
-
     }
 
 

--- a/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
@@ -98,23 +98,20 @@ namespace Eurofurence.App.Server.Web.Controllers
         [ProducesResponseType(typeof(string), 404)]
         public ActionResult GetDataMatrixCode()
         {
-            if (User.Identity is ClaimsIdentity identity)
+            if (User.Identity is ClaimsIdentity identity && _identityService.GetRegistrationsIds(identity).Any())
             {
-                if (_identityService.GetRegistrationsIds(identity).Any())
+                try
                 {
-                    try
-                    {
-                        string fileExtension = MimeTypes.MimeTypeMap.GetExtension(Request.Headers.Accept);
-                        return File(
-                            Encoding.UTF8.GetBytes(
-                                _identityService.GenerateUserMatrixCode(User.Identity as ClaimsIdentity)),
-                            Request.Headers.Accept,
-                            $"matrix{fileExtension}");
-                    }
-                    catch (Exception e) when (e is ArgumentException or FormatException)
-                    {
-                        return BadRequest("Accept header not recognized - unknown format");
-                    }
+                    string fileExtension = MimeTypes.MimeTypeMap.GetExtension(Request.Headers.Accept);
+                    return File(
+                        Encoding.UTF8.GetBytes(
+                            _identityService.GenerateUserMatrixCode(User.Identity as ClaimsIdentity)),
+                        Request.Headers.Accept,
+                        $"matrix{fileExtension}");
+                }
+                catch (Exception e) when (e is ArgumentException or FormatException)
+                {
+                    return BadRequest("Accept header not recognized - unknown format");
                 }
             }
             return NotFound();

--- a/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
@@ -100,7 +100,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         {
             if (User.Identity is ClaimsIdentity identity)
             {
-                if (_identityService.GetRegistrations(identity).Any())
+                if (_identityService.GetRegistrationsIds(identity).Any())
                 {
                     try
                     {

--- a/src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj
+++ b/src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0" />
     <PackageReference Include="Mapster.DependencyInjection" Version="10.0.7" />
     <PackageReference Include="Markdig" Version="1.2.0" />
-	  <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
-	  <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.5" />
     <PackageReference Include="MimeTypeMapOfficial" Version="1.0.17" />
     <PackageReference Include="Minio" Version="7.0.0" />
     <PackageReference Include="Quartz.AspNetCore" Version="3.17.1" />

--- a/src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj
+++ b/src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Markdig" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.5" />
+    <PackageReference Include="MimeTypeMapOfficial" Version="1.0.17" />
     <PackageReference Include="Minio" Version="7.0.0" />
     <PackageReference Include="Quartz.AspNetCore" Version="3.17.1" />
     <PackageReference Include="Sentry.AspNetCore" Version="6.3.1" />


### PR DESCRIPTION
Closes #373 

Removes the role requirement for the Users/pass endpoint.
If the user has no active registration, a 404 is returned; otherwise, the latest registration is returned.

Furthermore, the image type of the matrix code can now be changed by the `Accept` header.