### PR TITLE
fix: add new SecurityRequirement to swagger configuration

### DIFF
--- a/src/Eurofurence.App.Server.Web/Startup/ServiceCollectionExtensions.cs
+++ b/src/Eurofurence.App.Server.Web/Startup/ServiceCollectionExtensions.cs
@@ -116,6 +116,11 @@ namespace Eurofurence.App.Server.Web.Startup
                     Type = SecuritySchemeType.Http
                 });
 
+                options.AddSecurityRequirement(document => new OpenApiSecurityRequirement
+                {
+                    [new OpenApiSecuritySchemeReference("Bearer", document)] = []
+                });
+
                 options.AddSecurityDefinition(ApiKeyAuthenticationDefaults.AuthenticationScheme,
                     new OpenApiSecurityScheme
                     {


### PR DESCRIPTION
With some swagger update, the configuration must have changed, and the Bearer token is not sent anymore.

According to the swagger docs, we need to add a new SecurityRequirement.