### PR TITLE
refactor: changed datamatrix image type specification

### DIFF
--- a/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
@@ -96,7 +96,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         [HttpGet("pass")]
         [ProducesResponseType(typeof(FileContentResult), 200)]
         [ProducesResponseType(typeof(string), 404)]
-        public ActionResult GetDataMatrixCode([FromQuery] string imageType)
+        public ActionResult GetDataMatrixCode([Required][FromQuery] string imageType)
         {
             if (User.Identity is ClaimsIdentity identity && _identityService.GetRegistrationsIds(identity).Any())
             {

--- a/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
@@ -93,7 +93,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// </summary>
         /// <param name="imageType">The image type the resulting data matrix code should have.</param>
         /// <returns>Data matrix code as svg.</returns>
-        [HttpGet("pass")]
+        [HttpGet("Pass")]
         [ProducesResponseType(typeof(FileContentResult), 200)]
         [ProducesResponseType(typeof(string), 404)]
         public ActionResult GetDataMatrixCode([Required][FromQuery] string imageType)

--- a/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
@@ -96,9 +96,15 @@ namespace Eurofurence.App.Server.Web.Controllers
         [HttpGet("Pass")]
         [ProducesResponseType(typeof(FileContentResult), 200)]
         [ProducesResponseType(typeof(string), 404)]
+        [Authorize]
         public ActionResult GetDataMatrixCode([Required][FromQuery] string imageType)
         {
-            if (User.Identity is ClaimsIdentity identity && _identityService.GetRegistrationsIds(identity).Any())
+            if (User.Identity is not ClaimsIdentity identity)
+            {
+                return Unauthorized();
+            }
+
+            if (_identityService.GetRegistrationsIds(identity).Any())
             {
                 try
                 {

--- a/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using System.Net.Mime;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
@@ -92,17 +91,18 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// The image format can be specified by the Accept header.
         /// It should be the same as the code on the con badge.
         /// </summary>
+        /// <param name="imageType">The image type the resulting data matrix code should have.</param>
         /// <returns>Data matrix code as svg.</returns>
         [HttpGet("pass")]
         [ProducesResponseType(typeof(FileContentResult), 200)]
         [ProducesResponseType(typeof(string), 404)]
-        public ActionResult GetDataMatrixCode()
+        public ActionResult GetDataMatrixCode([FromQuery] string imageType)
         {
             if (User.Identity is ClaimsIdentity identity && _identityService.GetRegistrationsIds(identity).Any())
             {
                 try
                 {
-                    string fileExtension = MimeTypes.MimeTypeMap.GetExtension(Request.Headers.Accept);
+                    string fileExtension = MimeTypes.MimeTypeMap.GetExtension(imageType);
                     return File(
                         Encoding.UTF8.GetBytes(
                             _identityService.GenerateUserMatrixCode(identity)),
@@ -111,7 +111,7 @@ namespace Eurofurence.App.Server.Web.Controllers
                 }
                 catch (Exception e) when (e is ArgumentException or FormatException)
                 {
-                    return BadRequest("Accept header not recognized - unknown format");
+                    return BadRequest("Image type header not recognized - unknown format");
                 }
             }
             return NotFound();

--- a/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
@@ -111,7 +111,7 @@ namespace Eurofurence.App.Server.Web.Controllers
                 }
                 catch (Exception e) when (e is ArgumentException or FormatException)
                 {
-                    return BadRequest("Image type header not recognized - unknown format");
+                    return BadRequest("Image type not recognized - unknown format");
                 }
             }
             return NotFound();

--- a/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
@@ -105,8 +105,8 @@ namespace Eurofurence.App.Server.Web.Controllers
                     string fileExtension = MimeTypes.MimeTypeMap.GetExtension(Request.Headers.Accept);
                     return File(
                         Encoding.UTF8.GetBytes(
-                            _identityService.GenerateUserMatrixCode(User.Identity as ClaimsIdentity)),
-                        Request.Headers.Accept,
+                            _identityService.GenerateUserMatrixCode(identity)),
+                        imageType,
                         $"matrix{fileExtension}");
                 }
                 catch (Exception e) when (e is ArgumentException or FormatException)

--- a/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
@@ -111,7 +111,7 @@ namespace Eurofurence.App.Server.Web.Controllers
                 }
                 catch (Exception e) when (e is ArgumentException or FormatException)
                 {
-                    return BadRequest("Image type not recognized - unknown format");
+                    return BadRequest("Image type not recognized - unknown or unsupported format");
                 }
             }
             return NotFound();


### PR DESCRIPTION
The Accept header might not be appropriate for specifying the image type.

Now we should use a separate URL parameter for that.

Also, the endpoint name `/pass` was changed to `/Pass` for consistency.