### PR TITLE
build(deps): Updated dependencies where sufficient

### DIFF
--- a/src/Eurofurence.App.Backoffice/Eurofurence.App.Backoffice.csproj
+++ b/src/Eurofurence.App.Backoffice/Eurofurence.App.Backoffice.csproj
@@ -11,15 +11,15 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Markdig" Version="1.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageReference Include="MudBlazor" Version="9.3.0" />
-    <PackageReference Include="Sentry.AspNetCore.Blazor.WebAssembly" Version="6.3.1" />
+    <PackageReference Include="MudBlazor" Version="9.5.0" />
+    <PackageReference Include="Sentry.AspNetCore.Blazor.WebAssembly" Version="6.6.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Eurofurence.App.Domain.Model\Eurofurence.App.Domain.Model.csproj" />

--- a/src/Eurofurence.App.Infrastructure.EntityFramework/Eurofurence.App.Infrastructure.EntityFramework.csproj
+++ b/src/Eurofurence.App.Infrastructure.EntityFramework/Eurofurence.App.Infrastructure.EntityFramework.csproj
@@ -18,14 +18,14 @@
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
-	<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
-	<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-	<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.8" />
-	<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+	<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+	<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+	<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
+	<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 	<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
 	<PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
 	<PackageReference Include="Pomelo.EntityFrameworkCore.MySql.Json.Microsoft" Version="8.0.3" />
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Eurofurence.App.Domain.Model\Eurofurence.App.Domain.Model.csproj" />

--- a/src/Eurofurence.App.Server.Services/Eurofurence.App.Server.Services.csproj
+++ b/src/Eurofurence.App.Server.Services/Eurofurence.App.Server.Services.csproj
@@ -24,20 +24,20 @@
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
     <PackageReference Include="Ical.Net" Version="5.2.2" />
     <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
     <PackageReference Include="Minio" Version="7.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
-    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/Eurofurence.App.Server.Services/Eurofurence.App.Server.Services.csproj
+++ b/src/Eurofurence.App.Server.Services/Eurofurence.App.Server.Services.csproj
@@ -20,10 +20,10 @@
     <PackageReference Include="dotAPNS" Version="4.6.0" />
     <PackageReference Include="DataMatrix.NetCore" Version="0.4.2" />
     <PackageReference Include="dotAPNS.AspNetCore" Version="2.2.2" />
+    <PackageReference Include="Duende.AspNetCore.Authentication.OAuth2Introspection" Version="7.0.1" />
     <PackageReference Include="FirebaseAdmin" Version="3.5.0" />
     <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
     <PackageReference Include="Ical.Net" Version="5.2.2" />
-    <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />

--- a/src/Eurofurence.App.Server.Services/Identity/IdentityService.cs
+++ b/src/Eurofurence.App.Server.Services/Identity/IdentityService.cs
@@ -3,8 +3,6 @@ using Eurofurence.App.Domain.Model.PushNotifications;
 using Eurofurence.App.Domain.Model.Users;
 using Eurofurence.App.Infrastructure.EntityFramework;
 using Eurofurence.App.Server.Services.Abstractions.Identity;
-using IdentityModel.AspNetCore.OAuth2Introspection;
-using IdentityModel.Client;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Options;
@@ -20,6 +18,8 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using DataMatrix.NetCore;
+using Duende.AspNetCore.Authentication.OAuth2Introspection;
+using Duende.IdentityModel.Client;
 
 namespace Eurofurence.App.Server.Services.Identity
 {

--- a/src/Eurofurence.App.Server.Web/Controllers/CommunicationController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/CommunicationController.cs
@@ -9,7 +9,7 @@ using Eurofurence.App.Server.Services.Abstractions.Communication;
 using Eurofurence.App.Server.Services.Abstractions.Security;
 using Eurofurence.App.Server.Web.Extensions;
 using Eurofurence.App.Server.Web.Identity;
-using IdentityModel.AspNetCore.OAuth2Introspection;
+using Duende.AspNetCore.Authentication.OAuth2Introspection;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj
+++ b/src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="dotAPNS" Version="4.6.0" />
     <PackageReference Include="dotAPNS.AspNetCore" Version="2.2.2" />
-    <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0" />
     <PackageReference Include="Mapster.DependencyInjection" Version="10.0.8" />
     <PackageReference Include="Markdig" Version="1.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />

--- a/src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj
+++ b/src/Eurofurence.App.Server.Web/Eurofurence.App.Server.Web.csproj
@@ -17,18 +17,18 @@
     <PackageReference Include="Mapster.DependencyInjection" Version="10.0.8" />
     <PackageReference Include="Markdig" Version="1.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.9" />
     <PackageReference Include="MimeTypeMapOfficial" Version="1.0.17" />
     <PackageReference Include="Minio" Version="7.0.0" />
-    <PackageReference Include="Quartz.AspNetCore" Version="3.17.1" />
-    <PackageReference Include="Sentry.AspNetCore" Version="6.3.1" />
+    <PackageReference Include="Quartz.AspNetCore" Version="3.18.1" />
+    <PackageReference Include="Sentry.AspNetCore" Version="6.6.0" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/Eurofurence.App.Server.Web/Identity/ConfigureOAuth2IntrospectionOptions.cs
+++ b/src/Eurofurence.App.Server.Web/Identity/ConfigureOAuth2IntrospectionOptions.cs
@@ -1,8 +1,9 @@
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Eurofurence.App.Server.Services.Abstractions.Identity;
-using IdentityModel.AspNetCore.OAuth2Introspection;
+using Duende.AspNetCore.Authentication.OAuth2Introspection;
 using Microsoft.Extensions.Options;
+using Duende.AspNetCore.Authentication.OAuth2Introspection.Context;
 
 namespace Eurofurence.App.Server.Web.Identity;
 

--- a/src/Eurofurence.App.Server.Web/Program.cs
+++ b/src/Eurofurence.App.Server.Web/Program.cs
@@ -1,4 +1,5 @@
 ﻿using dotAPNS.AspNetCore;
+using Duende.AspNetCore.Authentication.OAuth2Introspection;
 using Eurofurence.App.Infrastructure.EntityFramework;
 using Eurofurence.App.Server.Services.Abstractions;
 using Eurofurence.App.Server.Services.Abstractions.Announcements;
@@ -14,7 +15,6 @@ using Eurofurence.App.Server.Services.Abstractions.QrCode;
 using Eurofurence.App.Server.Web.Extensions;
 using Eurofurence.App.Server.Web.Identity;
 using Eurofurence.App.Server.Web.Startup;
-using IdentityModel.AspNetCore.OAuth2Introspection;
 using Mapster;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
@@ -133,8 +133,12 @@ namespace Eurofurence.App.Server.Web
             builder.Services.AddSwagger(globalOptions);
 
             builder.Services.AddTransient<IClaimsTransformation, RolesClaimsTransformation>();
+
+            builder.Services.AddDistributedMemoryCache();
+            builder.Services.AddHybridCache();
+
             builder.Services.AddAuthentication(OAuth2IntrospectionDefaults.AuthenticationScheme)
-                .AddOAuth2Introspection(options => { options.EnableCaching = true; })
+                .AddOAuth2Introspection()
                 .AddScheme<ApiKeyAuthenticationOptions, ApiKeyAuthenticationHandler>
                 (ApiKeyAuthenticationDefaults.AuthenticationScheme,
                     options =>

--- a/test/Eurofurence.App.Domain.Model.Tests/Eurofurence.App.Domain.Model.Tests.csproj
+++ b/test/Eurofurence.App.Domain.Model.Tests/Eurofurence.App.Domain.Model.Tests.csproj
@@ -10,9 +10,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/test/Eurofurence.App.Server.Services.Tests/Eurofurence.App.Server.Services.Tests.csproj
+++ b/test/Eurofurence.App.Server.Services.Tests/Eurofurence.App.Server.Services.Tests.csproj
@@ -5,17 +5,17 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Markdig" Version="1.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.5" />
+    <PackageReference Include="System.Text.Json" Version="10.0.9" />
     <PackageReference Include="Xunit.Microsoft.DependencyInjection" Version="10.0.4" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- Updated dependencies where sufficient, fixing vulnarability warning and build issues.
- Replaced depcreated and vulnerable IdentityModel.AspNetCore.OAuth2Introspection with Duende.AspNetCore.Authentication.OAuth2Introspection, which is the rebranding
  -> This now uses the Asp.NET default caching by default, therefore added .AddDistributedMemoryCache and .AddHybridCache  in startup pipeline

Not updated:
- ImageSharp needs a community license for version 4.0.0, which has to be obtained from their website via a form (https://licensing.sixlabors.com/)
- Pomelo and base EntityFramework libraries can't be updated, because Pomelon currently does not have .NET 10 support yet
