### PR TITLE
feat(events): use schedule version for sync

### DIFF
--- a/src/Eurofurence.App.Domain.Model/Events/Pretalx/PretalxSchedule.cs
+++ b/src/Eurofurence.App.Domain.Model/Events/Pretalx/PretalxSchedule.cs
@@ -8,7 +8,7 @@ namespace Eurofurence.App.Domain.Model.Events.Pretalx
     /// 
     /// see https://docs.pretalx.org/api/resources/#tag/schedules/operation/schedules_retrieve
     /// </summary>
-    public class PretalxSchedule<SlotType> where SlotType : PretalxSlot
+    public class PretalxSchedule<SlotType>
     {
         public int Id { get; init; }
         public string Version { get; init; }

--- a/src/Eurofurence.App.Server.Services/Abstractions/Events/IEventService.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/Events/IEventService.cs
@@ -1,10 +1,10 @@
-using Eurofurence.App.Domain.Model.Events;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Eurofurence.App.Domain.Model.Events;
 using Eurofurence.App.Domain.Model.PushNotifications;
 using Ical.Net;
 
@@ -51,5 +51,17 @@ namespace Eurofurence.App.Server.Services.Abstractions.Events
         /// <param name="user">The user whose events should be returned</param>
         /// <returns>A <see cref="Calendar"/> instance with all favorite events of the user </returns>
         Calendar GetFavoriteEventsFromUserAsIcal([NotNull] UserRecord user);
+
+        /// <summary>
+        /// Retrieve the last successfully synced version of the schedule since launch of the current
+        /// backend instance.
+        /// 
+        /// See: https://docs.pretalx.org/api/resources/#tag/schedules
+        /// </summary>
+        /// <returns>
+        /// Version string from last successfully synced schedule or <c>null</c> if no successful
+        /// sync since launch.
+        /// </returns>
+        string GetScheduleVersion();
     }
 }

--- a/src/Eurofurence.App.Server.Services/Events/EventService.cs
+++ b/src/Eurofurence.App.Server.Services/Events/EventService.cs
@@ -144,16 +144,6 @@ namespace Eurofurence.App.Server.Services.Events
             await _appDbContext.SaveChangesAsync();
         }
 
-        /// <summary>
-        /// Retrieve the last successfully synced version of the schedule since launch of the current
-        /// backend instance.
-        /// 
-        /// See: https://docs.pretalx.org/api/resources/#tag/schedules
-        /// </summary>
-        /// <returns>
-        /// Version string from last successfully synced schedule or <c>null</c> if no successful
-        /// sync since launch.
-        /// </returns>
         public string GetScheduleVersion()
         {
             return _cache.GetString(ScheduleVersionCacheKey);

--- a/src/Eurofurence.App.Server.Services/Events/EventService.cs
+++ b/src/Eurofurence.App.Server.Services/Events/EventService.cs
@@ -1,28 +1,29 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using AngleSharp.Common;
 using Eurofurence.App.Common.DataDiffUtils;
 using Eurofurence.App.Domain.Model.Events;
+using Eurofurence.App.Domain.Model.Events.Pretalx;
+using Eurofurence.App.Domain.Model.PushNotifications;
 using Eurofurence.App.Infrastructure.EntityFramework;
 using Eurofurence.App.Server.Services.Abstractions;
 using Eurofurence.App.Server.Services.Abstractions.Events;
-using Microsoft.Extensions.Logging;
-using System.Net.Http;
-using System.Security.Claims;
-using Eurofurence.App.Domain.Model.PushNotifications;
 using Eurofurence.App.Server.Services.Abstractions.Security;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Calendar = Ical.Net.Calendar;
-using System.Net.Http.Json;
-using Eurofurence.App.Domain.Model.Events.Pretalx;
-using System.Collections.Immutable;
-using AngleSharp.Common;
 
 namespace Eurofurence.App.Server.Services.Events
 {
@@ -35,10 +36,16 @@ namespace Eurofurence.App.Server.Services.Events
         private readonly IEventConferenceTrackService _eventConferenceTrackService;
         private readonly EventOptions _eventOptions;
         private readonly AppDbContext _appDbContext;
+        private readonly IDistributedCache _cache;
 
         private static readonly SemaphoreSlim Semaphore = new(1, 1);
 
         private TimeSpan DateTimeOffset { get; set; }
+
+        /// <summary>
+        /// Cache key used for storing the last successfully synced schedule version.
+        /// </summary>
+        private const string ScheduleVersionCacheKey = "EventService::LastSyncedScheduleVersion";
 
         public EventService(
             AppDbContext appDbContext,
@@ -47,7 +54,8 @@ namespace Eurofurence.App.Server.Services.Events
             IEventConferenceRoomService eventConferenceRoomService,
             IEventConferenceTrackService eventConferenceTrackService,
             ILoggerFactory loggerFactory,
-            IOptions<EventOptions> eventOptions
+            IOptions<EventOptions> eventOptions,
+            IDistributedCache cache
         )
             : base(appDbContext, storageServiceFactory)
         {
@@ -58,6 +66,7 @@ namespace Eurofurence.App.Server.Services.Events
             _eventOptions = eventOptions.Value;
             DateTimeOffset = TimeSpan.Zero;
             _logger = loggerFactory.CreateLogger(GetType());
+            _cache = cache;
         }
 
 
@@ -135,6 +144,31 @@ namespace Eurofurence.App.Server.Services.Events
             await _appDbContext.SaveChangesAsync();
         }
 
+        /// <summary>
+        /// Retrieve the last successfully synced version of the schedule since launch of the current
+        /// backend instance.
+        /// 
+        /// See: https://docs.pretalx.org/api/resources/#tag/schedules
+        /// </summary>
+        /// <returns>
+        /// Version string from last successfully synced schedule or <c>null</c> if no successful
+        /// sync since launch.
+        /// </returns>
+        public string GetScheduleVersion()
+        {
+            return _cache.GetString(ScheduleVersionCacheKey);
+        }
+
+        /// <summary>
+        /// Update the last successfully synced schedule version, preventing a schedule with the same
+        /// version from being imported again.
+        /// </summary>
+        /// <param name="scheduleVersion">Version string or <c>null</c> to force import on next sync.</param>
+        private void SetScheduleVersion(string scheduleVersion)
+        {
+            _cache.SetString(ScheduleVersionCacheKey, scheduleVersion);
+        }
+
         public IQueryable<EventRecord> FindConflicts(DateTime conflictStartTime, DateTime conflictEndTime,
             TimeSpan tolerance, bool includeInternal)
         {
@@ -156,6 +190,16 @@ namespace Eurofurence.App.Server.Services.Events
 
                 var httpClient = new HttpClient();
                 httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Token", _eventOptions.ApiKey);
+
+                var pretalxSchedulePrefetch = await httpClient.GetFromJsonAsync<PretalxSchedule<int>>($"{_eventOptions.ApiUrl}/events/{_eventOptions.EventSlug}/schedules/latest/");
+                var lastScheduleVersion = GetScheduleVersion();
+                if (pretalxSchedulePrefetch.Version.Equals(lastScheduleVersion))
+                {
+                    _logger.LogInformation(LogEvents.Import,
+                        $"Last successfully imported version {lastScheduleVersion ?? "<none>"} is equal to latest available version {pretalxSchedulePrefetch.Version}. Skipping import…");
+                    return;
+                }
+
                 var pretalxSchedule = await httpClient.GetFromJsonAsync<PretalxSchedule<PretalxSlot>>($"{_eventOptions.ApiUrl}/events/{_eventOptions.EventSlug}/schedules/latest/?expand=slots,slots.room,slots.submission,slots.submission.speakers,slots.submission.submission_type,slots.submission.track");
 
                 var tags = new List<PretalxTag>();
@@ -199,8 +243,10 @@ namespace Eurofurence.App.Server.Services.Events
                     eventConferenceDays.Item2,
                     tags.ToDictionary(tag => tag.Id, tag => tag));
 
+                SetScheduleVersion(pretalxSchedule.Version);
+
                 _logger.LogInformation(LogEvents.Import,
-                    $"Event import finished successfully modifying {eventConferenceTracks.Item1} EventConferenceTrack(s), {eventConferenceRooms.Item1} EventConferenceRoom(s), {eventConferenceDays.Item1} EventConferenceDay(s) and {eventEntries.Item1} Event(s).");
+                    $"Event import for schedule version {pretalxSchedule.Version} finished successfully modifying {eventConferenceTracks.Item1} of {tracks.Count} EventConferenceTrack(s), {eventConferenceRooms.Item1} of {rooms.Count} EventConferenceRoom(s), {eventConferenceDays.Item1} of {days.Count} EventConferenceDay(s) and {eventEntries.Item1} of {slots.Count()} Event(s) from previously imported version {lastScheduleVersion ?? "<none>"}.");
             }
             finally
             {

--- a/src/Eurofurence.App.Server.Web/Controllers/EventsController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/EventsController.cs
@@ -55,6 +55,26 @@ namespace Eurofurence.App.Server.Web.Controllers
         }
 
         /// <summary>
+        ///     Retrieves the last successfully synced schedule version string.
+        /// </summary>
+        /// <returns>Schedule version or 404 if no sync has run since last restart.</returns>
+        [AllowAnonymous]
+        [HttpGet("Version")]
+        [ProducesResponseType(typeof(string), 404)]
+        [ProducesResponseType(typeof(string), 200)]
+        public ActionResult GetScheduleVersion()
+        {
+            if (_eventService.GetScheduleVersion() is string scheduleVersion)
+            {
+                return Ok(scheduleVersion);
+            }
+            else
+            {
+                return NotFound("Schedule sync pending.");
+            }
+        }
+
+        /// <summary>
         ///     Retrieves a list of all events in the event schedule that
         ///     conflict with the specified start/end time, +/- a tolerance
         ///     in minutes that is considered when calculating overlaps.


### PR DESCRIPTION
* reduce load due to unnecessary event imports by checking the schedule version ahead of performing a full fetch & import
* expose latest imported schedule version via API