### PR TITLE
feat: add event feedback get endpoint

### DIFF
--- a/src/Eurofurence.App.Domain.Model/Events/EventFeedbackResponse.cs
+++ b/src/Eurofurence.App.Domain.Model/Events/EventFeedbackResponse.cs
@@ -9,6 +9,12 @@ namespace Eurofurence.App.Domain.Model.Events
         public Guid EventId { get; set; }
 
         [DataMember]
+        public string EventSlug { get; set; }
+
+        [DataMember]
+        public string EventSourceId { get; set; }
+
+        [DataMember]
         public int Rating { get; set; }
 
         [DataMember]

--- a/src/Eurofurence.App.Domain.Model/Events/EventFeedbackResponseRegister.cs
+++ b/src/Eurofurence.App.Domain.Model/Events/EventFeedbackResponseRegister.cs
@@ -1,0 +1,14 @@
+using Mapster;
+
+namespace Eurofurence.App.Domain.Model.Events;
+
+public class EventFeedbackResponseRegister : IRegister
+{
+    public void Register(TypeAdapterConfig config)
+    {
+        config.NewConfig<EventFeedbackRecord, EventFeedbackResponse>()
+            .Map(dest => dest.EventSlug, src => src.Event.Slug)
+            .Map(dest => dest.EventSourceId, src => src.Event.SourceId)
+            .PreserveReference(true);
+    }
+}

--- a/src/Eurofurence.App.Server.Services/Abstractions/Identity/AuthorizationOptions.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/Identity/AuthorizationOptions.cs
@@ -10,6 +10,8 @@ public class AuthorizationOptions
 
     public HashSet<string> AttendeeCheckedIn { get; init; } = new();
 
+    public HashSet<string> EventFeedbackManager { get; init; } = new();
+
     public HashSet<string> Staff { get; init; } = new();
 
     public HashSet<string> KnowledgeBaseEditor { get; init; } = new();

--- a/src/Eurofurence.App.Server.Services/Events/EventFeedbackService.cs
+++ b/src/Eurofurence.App.Server.Services/Events/EventFeedbackService.cs
@@ -1,7 +1,9 @@
-﻿using Eurofurence.App.Domain.Model.Events;
+﻿using System.Linq;
+using Eurofurence.App.Domain.Model.Events;
 using Eurofurence.App.Infrastructure.EntityFramework;
 using Eurofurence.App.Server.Services.Abstractions;
 using Eurofurence.App.Server.Services.Abstractions.Events;
+using Microsoft.EntityFrameworkCore;
 
 namespace Eurofurence.App.Server.Services.Events
 {
@@ -14,6 +16,11 @@ namespace Eurofurence.App.Server.Services.Events
         )
             : base(appDbContext, storageServiceFactory)
         {
+        }
+
+        public override IQueryable<EventFeedbackRecord> FindAll()
+        {
+            return base.FindAll().Include(x => x.Event);
         }
     }
 }

--- a/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
@@ -55,18 +55,18 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <summary>
         /// Returns all event feedback records filterable by event id.
         /// </summary>
-        /// <param name="filterEventId">Optional event source id filter.</param>
+        /// <param name="eventSourceId">Optional event source id filter.</param>
         /// <returns>A list of all event's (or filtered) feedback.</returns>
         [Authorize(Roles = "EventFeedbackManager")]
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<EventFeedbackResponse>), 200)]
-        public ActionResult GetEventFeedback(int? filterEventId)
+        public ActionResult GetEventFeedback(int? eventSourceId)
         {
             IEnumerable<EventFeedbackRecord> records = _eventFeedbackService.FindAll();
             EventFeedbackRecord first = records.FirstOrDefault();
-            if (filterEventId != null)
+            if (eventSourceId != null)
             {
-                records = records.Where(x => x.Event.SourceId == filterEventId);
+                records = records.Where(x => x.Event.SourceId == eventSourceId);
             }
             return Ok(records.Select(x => x.Transform()));
         }

--- a/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
@@ -59,6 +59,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <returns>A list of all event's (or filtered) feedback.</returns>
         [Authorize(Roles = "EventFeedbackManager")]
         [HttpGet]
+        [ProducesResponseType(typeof(IEnumerable<EventFeedbackResponse>), 200)]
         public ActionResult GetEventFeedback(Guid filterId)
         {
             IEnumerable<EventFeedbackRecord> records = _eventFeedbackService.FindAll();

--- a/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
@@ -57,7 +57,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// </summary>
         /// <param name="filterId">Optional event filter.</param>
         /// <returns>A list of all event's (or filtered) feedback.</returns>
-        [Authorize(Roles = "Admin")]
+        [Authorize(Roles = "EventFeedbackManager")]
         [HttpGet]
         public ActionResult GetEventFeedback(Guid filterId)
         {

--- a/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
@@ -63,7 +63,6 @@ namespace Eurofurence.App.Server.Web.Controllers
         public ActionResult GetEventFeedback(int? eventSourceId)
         {
             IEnumerable<EventFeedbackRecord> records = _eventFeedbackService.FindAll();
-            EventFeedbackRecord first = records.FirstOrDefault();
             if (eventSourceId != null)
             {
                 records = records.Where(x => x.Event.SourceId == eventSourceId);

--- a/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
@@ -55,17 +55,18 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// <summary>
         /// Returns all event feedback records filterable by event id.
         /// </summary>
-        /// <param name="filterId">Optional event filter.</param>
+        /// <param name="filterEventId">Optional event source id filter.</param>
         /// <returns>A list of all event's (or filtered) feedback.</returns>
         [Authorize(Roles = "EventFeedbackManager")]
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<EventFeedbackResponse>), 200)]
-        public ActionResult GetEventFeedback(Guid filterId)
+        public ActionResult GetEventFeedback(int? filterEventId)
         {
             IEnumerable<EventFeedbackRecord> records = _eventFeedbackService.FindAll();
-            if (filterId != Guid.Empty)
+            EventFeedbackRecord first = records.FirstOrDefault();
+            if (filterEventId != null)
             {
-                records = records.Where(x => x.EventId == filterId);
+                records = records.Where(x => x.Event.SourceId == filterEventId);
             }
             return Ok(records.Select(x => x.Transform()));
         }

--- a/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
@@ -1,5 +1,9 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Eurofurence.App.Domain.Model.Events;
+using Eurofurence.App.Domain.Model.Transformers;
 using Eurofurence.App.Server.Services.Abstractions.Events;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -46,6 +50,23 @@ namespace Eurofurence.App.Server.Web.Controllers
             await _eventFeedbackService.InsertOneAsync(record);
 
             return NoContent();
+        }
+
+        /// <summary>
+        /// Returns all event feedback records filterable by event id.
+        /// </summary>
+        /// <param name="filterId">Optional event filter.</param>
+        /// <returns>A list of all event's (or filtered) feedback.</returns>
+        [Authorize(Roles = "Admin")]
+        [HttpGet]
+        public ActionResult GetEventFeedback(Guid filterId)
+        {
+            IEnumerable<EventFeedbackRecord> records = _eventFeedbackService.FindAll();
+            if (filterId != Guid.Empty)
+            {
+                records = records.Where(x => x.EventId == filterId);
+            }
+            return Ok(records.Select(x => x.Transform()));
         }
     }
 }

--- a/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
@@ -57,7 +57,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         /// </summary>
         /// <param name="eventSourceId">Optional event source id filter.</param>
         /// <returns>A list of all event's (or filtered) feedback.</returns>
-        [Authorize(Roles = "EventFeedbackManager")]
+        [Authorize(Roles = "Admin, EventFeedbackManager")]
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<EventFeedbackResponse>), 200)]
         public ActionResult GetEventFeedback(int? eventSourceId)

--- a/src/Eurofurence.App.Server.Web/Identity/RolesClaimsTransformation.cs
+++ b/src/Eurofurence.App.Server.Web/Identity/RolesClaimsTransformation.cs
@@ -63,6 +63,11 @@ public class RolesClaimsTransformation(
                 roles.Add("AttendeeCheckedIn");
             }
 
+            if (authorizationOptions.Value.EventFeedbackManager.Contains(claim.Value))
+            {
+                roles.Add("EventFeedbackManager");
+            }
+
             if (authorizationOptions.Value.KnowledgeBaseEditor.Contains(claim.Value))
             {
                 roles.Add("KnowledgeBaseEditor");

--- a/src/Eurofurence.App.Server.Web/appsettings.sample.json
+++ b/src/Eurofurence.App.Server.Web/appsettings.sample.json
@@ -26,6 +26,7 @@
     "ArtShow": [],
     "Attendee": [],
     "AttendeeCheckedIn": [],
+    "EventFeedbackManager": [],
     "KnowledgeBaseEditor": [],
     "MapEditor": [],
     "PrivateMessageSender": [],


### PR DESCRIPTION
Closes #428 

Adds a new endpoint for getting all event feedback records filterable by an optional EventSourceId.