### PR TITLE
feat(events): enable tracking of event slots across schedules and setting all events to internal

### DIFF
--- a/src/Eurofurence.App.Domain.Model/Events/EventRecord.cs
+++ b/src/Eurofurence.App.Domain.Model/Events/EventRecord.cs
@@ -11,7 +11,7 @@ namespace Eurofurence.App.Domain.Model.Events
     public class EventRecord : EntityBase, IDtoRecordTransformable<EventRequest, EventResponse, EventRecord>
     {
         [JsonIgnore]
-        public int SourceId { get; set; }
+        public string SourceId { get; set; }
 
         [DataMember]
         public string Slug { get; set; }

--- a/src/Eurofurence.App.Domain.Model/Events/Pretalx/PretalxSlot.cs
+++ b/src/Eurofurence.App.Domain.Model/Events/Pretalx/PretalxSlot.cs
@@ -15,7 +15,7 @@ namespace Eurofurence.App.Domain.Model.Events.Pretalx
         public PretalxRoom Room { get; init; }
         public DateTime? Start { get; init; }
         public DateTime? End { get; init; }
-        public PretalxSubmission Submission { get; init; }
+        public PretalxSubmission? Submission { get; init; }
         public Dictionary<string, string> Description { get; init; }
         public int Duration { get; init; }
         /// <summary>

--- a/src/Eurofurence.App.Domain.Model/Events/Pretalx/PretalxSlot.cs
+++ b/src/Eurofurence.App.Domain.Model/Events/Pretalx/PretalxSlot.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Eurofurence.App.Domain.Model.Events.Pretalx
 {
@@ -17,5 +18,12 @@ namespace Eurofurence.App.Domain.Model.Events.Pretalx
         public PretalxSubmission Submission { get; init; }
         public Dictionary<string, string> Description { get; init; }
         public int Duration { get; init; }
+        /// <summary>
+        /// Artifical ID derived from either <c>Submission.Code</c> or the first six digits of an
+        /// MD5 hash including <c>Room</c>, <c>Start</c> and <c>End</c> plus an index of the six
+        /// digit code occurring within the schedule (e.g. if a submission has multiple slots).
+        /// </summary>
+        [JsonIgnore]
+        public string SourceId { get; set; }
     }
 }

--- a/src/Eurofurence.App.Domain.Model/Events/Pretalx/PretalxSlotWip.cs
+++ b/src/Eurofurence.App.Domain.Model/Events/Pretalx/PretalxSlotWip.cs
@@ -13,7 +13,7 @@ namespace Eurofurence.App.Domain.Model.Events.Pretalx
         [JsonPropertyName("submission")]
         public string SubmissionCode { get; init; }
         [JsonIgnore]
-        public new PretalxSubmission Submission
+        public new PretalxSubmission? Submission
         {
             get => SubmissionCode != null ? new PretalxSubmission { Code = SubmissionCode } : null;
         }

--- a/src/Eurofurence.App.Domain.Model/Events/Pretalx/PretalxSlotWip.cs
+++ b/src/Eurofurence.App.Domain.Model/Events/Pretalx/PretalxSlotWip.cs
@@ -15,7 +15,7 @@ namespace Eurofurence.App.Domain.Model.Events.Pretalx
         [JsonIgnore]
         public new PretalxSubmission Submission
         {
-            get => SubmissionCode != null ? new PretalxSubmission() : null;
+            get => SubmissionCode != null ? new PretalxSubmission { Code = SubmissionCode } : null;
         }
     }
 }

--- a/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20260712200812_ConvertEventSourceIdToString.Designer.cs
+++ b/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20260712200812_ConvertEventSourceIdToString.Designer.cs
@@ -4,6 +4,7 @@ using Eurofurence.App.Infrastructure.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Eurofurence.App.Infrastructure.EntityFramework.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260712200812_ConvertEventSourceIdToString")]
+    partial class ConvertEventSourceIdToString
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20260712200812_ConvertEventSourceIdToString.cs
+++ b/src/Eurofurence.App.Infrastructure.EntityFramework/Migrations/20260712200812_ConvertEventSourceIdToString.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eurofurence.App.Infrastructure.EntityFramework.Migrations
+{
+    /// <inheritdoc />
+    public partial class ConvertEventSourceIdToString : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "SourceId",
+                table: "Events",
+                type: "longtext",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "SourceId",
+                table: "Events",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(string),
+                oldType: "longtext",
+                oldNullable: true)
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/src/Eurofurence.App.Server.Services/Abstractions/Events/EventOptions.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/Events/EventOptions.cs
@@ -4,13 +4,47 @@ namespace Eurofurence.App.Server.Services.Abstractions.Events
 {
     public class EventOptions
     {
+        /// <summary>
+        /// Base-URL to the Pretalx API, usually ending in <c>/api</c>
+        /// </summary>
         public string ApiUrl { get; init; }
+        /// <summary>
+        /// Read-only API Key generated in Pretalx. Should have read list & details for events,
+        /// submissions, speakers, rooms, tags, tracks, schedules, slots, submission-types
+        /// </summary>
         public string ApiKey { get; init; }
+        /// <summary>
+        /// Slug identifying the actual event within the Pretalx instance.
+        /// </summary>
         public string EventSlug { get; init; }
+        /// <summary>
+        /// i18n is currently not used, thus a default locale for multi-language API fields must be
+        /// provided, specifying which language string should be used.
+        /// </summary>
         public string DefaultLocale { get; init; }
+        /// <summary>
+        /// ID of the Pretalx tag that identifies internal events (visible to staff only).
+        /// </summary>
         public int InternalTagId { get; init; }
+        /// <summary>
+        /// ID of the Pretalx track containing internal events (visible to staff only).
+        /// </summary>
         public int InternalTrackId { get; init; }
+        /// <summary>
+        /// Make all events internal (visible to staff only) independent of their track or tags.
+        /// Can be used during pre-production phase when schedule is not yet public, but in staff-
+        /// internal preview.
+        /// </summary>
+        public bool MarkAllInternal { get; init; }
+        /// <summary>
+        /// ID of the Pretalx tag marking events which accept feedback to be provided via the app.
+        /// </summary>
         public int AcceptsFeedbackTagId { get; init; }
+        /// <summary>
+        /// Maps ISO 8601 dates of convention days to display names for those days.
+        /// Example:
+        ///     1970-01-01 => Mon – Staff Arrival
+        /// </summary>
         public Dictionary<string, string> EventDays { get; init; }
     }
 }

--- a/src/Eurofurence.App.Server.Services/Events/EventService.cs
+++ b/src/Eurofurence.App.Server.Services/Events/EventService.cs
@@ -224,10 +224,10 @@ namespace Eurofurence.App.Server.Services.Events
                 var slotsPublic = _eventOptions.MarkAllInternal ?
                     new HashSet<PretalxSlot>()
                     :
-                    slots.Where(slot =>
+                    [.. slots.Where(slot =>
                         (!slot.Submission?.Tags.Contains(_eventOptions.InternalTagId) ?? false) &&
                         (!slot.Submission?.Track.Id.Equals(_eventOptions.InternalTrackId) ?? false)
-                    ).ToHashSet();
+                    )];
 
                 var tracks = slots.Where(slot => slot.Submission != null).Select(slot => slot.Submission.Track).ToHashSet();
                 var tracksPublic = slotsPublic.Select(slot => slot.Submission.Track).ToHashSet();
@@ -259,7 +259,7 @@ namespace Eurofurence.App.Server.Services.Events
             }
         }
 
-        private string GenerateUniquePretalxSlotSourceId(IEnumerable<PretalxSlot> importEventEntries, PretalxSlot source)
+        private static string GenerateUniquePretalxSlotSourceId(IEnumerable<PretalxSlot> importEventEntries, PretalxSlot source)
         {
             // Slots without submissions attached are either blockers or breaks, so if they move,
             // we just recreate them for the time being. This will break favorites on blockers and
@@ -269,17 +269,24 @@ namespace Eurofurence.App.Server.Services.Events
                     $"BLOCKR-{((DateTimeOffset?)source.Start)?.ToUnixTimeSeconds()}-{((DateTimeOffset?)source.End)?.ToUnixTimeSeconds()}-{source.Room.Id}"
                     )
                 )
-            ).Substring(0, 6);
+            )[..6];
 
             // Since the same submission may be in multiple 
-            var slotIndex = source.Submission != null ? importEventEntries.Where(entry => entry.Submission?.Code == source.Submission?.Code).OrderBy(entry => entry.Start).Index().SingleOrDefault(indexed => indexed.Item.Id == source.Id, new(0, null)).Index.ToString() : "BLOCKER";
+            var slotIndex = source.Submission == null ?
+                "BLOCKER"
+                :
+                importEventEntries.Where(entry => entry.Submission?.Code == source.Submission?.Code)
+                    .OrderBy(entry => entry.Start)
+                    .Index()
+                    .SingleOrDefault(indexed => indexed.Item.Id == source.Id, new(0, null))
+                    .Index.ToString();
 
             return $"{submissionCode}-{slotIndex}";
         }
 
         private async Task<Tuple<int, List<EventConferenceDayRecord>>> UpdateEventConferenceDaysAsync(
             IList<Tuple<DateTime, string>> importDays,
-            ISet<DateTime> importDaysPublic
+            HashSet<DateTime> importDaysPublic
         )
         {
             var eventConferenceDayRecords = _appDbContext.EventConferenceDays.AsNoTracking();
@@ -302,8 +309,8 @@ namespace Eurofurence.App.Server.Services.Events
 
 
         private async Task<Tuple<int, List<EventConferenceTrackRecord>>> UpdateEventConferenceTracksAsync(
-            ISet<PretalxTrack> importTracks,
-            ISet<PretalxTrack> importTracksPublic
+            HashSet<PretalxTrack> importTracks,
+            HashSet<PretalxTrack> importTracksPublic
         )
         {
             var eventConferenceTrackRecords = _appDbContext.EventConferenceTracks.AsNoTracking();
@@ -325,8 +332,8 @@ namespace Eurofurence.App.Server.Services.Events
         }
 
         private async Task<Tuple<int, List<EventConferenceRoomRecord>>> UpdateEventConferenceRoomsAsync(
-            ISet<PretalxRoom> importRooms,
-            ISet<PretalxRoom> importRoomsPublic
+            HashSet<PretalxRoom> importRooms,
+            HashSet<PretalxRoom> importRoomsPublic
         )
         {
             var eventConferenceRoomRecords = _appDbContext.EventConferenceRooms.AsNoTracking();
@@ -352,7 +359,7 @@ namespace Eurofurence.App.Server.Services.Events
 
         private async Task<Tuple<int, List<EventRecord>>> UpdateEventEntriesAsync(
             IEnumerable<PretalxSlot> importEventEntries,
-            ISet<PretalxSlot> importEventEntriesPublic,
+            HashSet<PretalxSlot> importEventEntriesPublic,
             IList<EventConferenceTrackRecord> currentConferenceTracks,
             IList<EventConferenceRoomRecord> currentConferenceRooms,
             IList<EventConferenceDayRecord> currentConferenceDays,
@@ -395,7 +402,7 @@ namespace Eurofurence.App.Server.Services.Events
             await ApplyPatchOperationAsync(diff);
 
             var modifiedRecords = diff.Count(a => a.Action != ActionEnum.NotModified);
-            return new Tuple<int, List<EventRecord>>(modifiedRecords, diff.Where(a => a.Entity.IsDeleted == 0).Select(a => a.Entity).ToList());
+            return new Tuple<int, List<EventRecord>>(modifiedRecords, [.. diff.Where(a => a.Entity.IsDeleted == 0).Select(a => a.Entity)]);
         }
     }
 }

--- a/src/Eurofurence.App.Server.Services/Events/EventService.cs
+++ b/src/Eurofurence.App.Server.Services/Events/EventService.cs
@@ -272,7 +272,7 @@ namespace Eurofurence.App.Server.Services.Events
             ).Substring(0, 6);
 
             // Since the same submission may be in multiple 
-            var slotIndex = importEventEntries.Where(entry => entry.Submission?.Code == source.Submission?.Code).OrderBy(entry => entry.Start).Index().SingleOrDefault(indexed => indexed.Item.Id == source.Id, new(0, null)).Index;
+            var slotIndex = source.Submission != null ? importEventEntries.Where(entry => entry.Submission?.Code == source.Submission?.Code).OrderBy(entry => entry.Start).Index().SingleOrDefault(indexed => indexed.Item.Id == source.Id, new(0, null)).Index.ToString() : "BLOCKER";
 
             return $"{submissionCode}-{slotIndex}";
         }
@@ -367,7 +367,7 @@ namespace Eurofurence.App.Server.Services.Events
 
             // Public breaks have no submission; their title can be found in the slot description.
             patch.Map(source => source.SourceId, target => target.SourceId)
-                .Map(source => source.SourceId, target => target.Slug)
+                .Map(source => source.Submission?.Code ?? source.SourceId?.Split('-')[0] ?? "UNKNWN", target => target.Slug)
                 .Map(source => (source.Submission?.Title ?? source.Description?.GetValueOrDefault(_eventOptions.DefaultLocale) ?? "").Split('–')[0]?.Trim(), target => target.Title)
                 .Map(source => ((source.Submission?.Title ?? source.Description?.GetValueOrDefault(_eventOptions.DefaultLocale) ?? "") + '–').Split('–')[1]?.Trim(), target => target.SubTitle)
                 .Map(source => source.Submission?.Abstract, target => target.Abstract)

--- a/src/Eurofurence.App.Server.Services/Events/EventService.cs
+++ b/src/Eurofurence.App.Server.Services/Events/EventService.cs
@@ -217,7 +217,8 @@ namespace Eurofurence.App.Server.Services.Events
                     new HashSet<PretalxSlot>()
                     :
                     slots.Where(slot =>
-                        !slot.Submission?.Tags.Contains(_eventOptions.InternalTagId) ?? false
+                        (!slot.Submission?.Tags.Contains(_eventOptions.InternalTagId) ?? false) &&
+                        (!slot.Submission?.Track.Id.Equals(_eventOptions.InternalTrackId) ?? false)
                     ).ToHashSet();
 
                 var tracks = slots.Where(slot => slot.Submission != null).Select(slot => slot.Submission.Track).ToHashSet();
@@ -233,6 +234,7 @@ namespace Eurofurence.App.Server.Services.Events
                 var eventConferenceRooms = await UpdateEventConferenceRoomsAsync(rooms, roomsPublic);
                 var eventConferenceDays = await UpdateEventConferenceDaysAsync(days, daysPublic);
                 var eventEntries = await UpdateEventEntriesAsync(slots,
+                    slotsPublic,
                     eventConferenceTracks.Item2,
                     eventConferenceRooms.Item2,
                     eventConferenceDays.Item2,
@@ -241,7 +243,7 @@ namespace Eurofurence.App.Server.Services.Events
                 SetScheduleVersion(pretalxSchedule.Version);
 
                 _logger.LogInformation(LogEvents.Import,
-                    $"Event import for schedule version {pretalxSchedule.Version} finished successfully modifying {eventConferenceTracks.Item1} of {tracks.Count} EventConferenceTrack(s), {eventConferenceRooms.Item1} of {rooms.Count} EventConferenceRoom(s), {eventConferenceDays.Item1} of {days.Count} EventConferenceDay(s) and {eventEntries.Item1} of {slots.Count()} Event(s) from previously imported version {lastScheduleVersion ?? "<none>"}.");
+                    $"Event import for schedule version {pretalxSchedule.Version} finished successfully modifying {eventConferenceTracks.Item1} of {tracks.Count} ({tracksPublic.Count()} public) EventConferenceTrack(s), {eventConferenceRooms.Item1} of {rooms.Count} ({roomsPublic.Count()} public) EventConferenceRoom(s), {eventConferenceDays.Item1} of {days.Count} ({daysPublic.Count()} public) EventConferenceDay(s) and {eventEntries.Item1} of {slots.Count()} ({slotsPublic.Count()} public) Event(s) from previously imported version {lastScheduleVersion ?? "<none>"}.");
             }
             finally
             {
@@ -324,6 +326,7 @@ namespace Eurofurence.App.Server.Services.Events
 
         private async Task<Tuple<int, List<EventRecord>>> UpdateEventEntriesAsync(
             IEnumerable<PretalxSlot> importEventEntries,
+            ISet<PretalxSlot> importEventEntriesPublic,
             IList<EventConferenceTrackRecord> currentConferenceTracks,
             IList<EventConferenceRoomRecord> currentConferenceRooms,
             IList<EventConferenceDayRecord> currentConferenceDays,
@@ -359,7 +362,7 @@ namespace Eurofurence.App.Server.Services.Events
                 .Map(source => source.Submission?.Tags.Contains(_eventOptions.AcceptsFeedbackTagId) ?? false,
                     target => target.IsAcceptingFeedback)
                 .Map(source => source.Submission?.Tags.Select(tagId => tags.GetOrDefault(tagId, null)?.Tag).ToArray() ?? [tags.GetOrDefault(_eventOptions.InternalTagId, null)?.Tag], target => target.Tags)
-                .Map(source => source.Submission?.Tags.Contains(_eventOptions.InternalTagId) ?? true, target => target.IsInternal);
+                .Map(source => !importEventEntriesPublic.Contains(source), target => target.IsInternal);
 
             var diff = patch.Patch(importEventEntries, eventRecords);
 

--- a/src/Eurofurence.App.Server.Services/Events/EventService.cs
+++ b/src/Eurofurence.App.Server.Services/Events/EventService.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using AngleSharp.Common;
@@ -213,6 +214,13 @@ namespace Eurofurence.App.Server.Services.Events
                 // Eurofurence and thus filtered out as well.
                 // Subsequently, all slots without submission can be considered internal blockers.
                 var slots = pretalxSchedule.Slots.Where(slot => slot.Start != null && slot.End != null && slot.Submission != null).Concat(slotsBlocker);
+
+                // Try to ensure we have a stable way of identifying slots across multiple schedule versions
+                foreach (var slot in slots)
+                {
+                    slot.SourceId = GenerateUniquePretalxSlotSourceId(slots, slot);
+                }
+
                 var slotsPublic = _eventOptions.MarkAllInternal ?
                     new HashSet<PretalxSlot>()
                     :
@@ -249,6 +257,24 @@ namespace Eurofurence.App.Server.Services.Events
             {
                 Semaphore.Release();
             }
+        }
+
+        private string GenerateUniquePretalxSlotSourceId(IEnumerable<PretalxSlot> importEventEntries, PretalxSlot source)
+        {
+            // Slots without submissions attached are either blockers or breaks, so if they move,
+            // we just recreate them for the time being. This will break favorites on blockers and
+            // breaks, but they are internal and limited use only anyways.
+            var submissionCode = source.Submission?.Code ?? Convert.ToHexString(
+                MD5.HashData(System.Text.Encoding.UTF8.GetBytes(
+                    $"BLOCKR-{((DateTimeOffset?)source.Start)?.ToUnixTimeSeconds()}-{((DateTimeOffset?)source.End)?.ToUnixTimeSeconds()}-{source.Room.Id}"
+                    )
+                )
+            ).Substring(0, 6);
+
+            // Since the same submission may be in multiple 
+            var slotIndex = importEventEntries.Where(entry => entry.Submission?.Code == source.Submission?.Code).OrderBy(entry => entry.Start).Index().SingleOrDefault(indexed => indexed.Item.Id == source.Id, new(0, null)).Index;
+
+            return $"{submissionCode}-{slotIndex}";
         }
 
         private async Task<Tuple<int, List<EventConferenceDayRecord>>> UpdateEventConferenceDaysAsync(
@@ -336,12 +362,12 @@ namespace Eurofurence.App.Server.Services.Events
             var eventRecords = FindAll();
 
             var patch = new PatchDefinition<PretalxSlot, EventRecord>(
-                (source, targets) => targets.SingleOrDefault(target => target.SourceId == source.Id)
+                (source, targets) => targets.SingleOrDefault(target => target.SourceId == source.SourceId)
             );
 
             // Public breaks have no submission; their title can be found in the slot description.
-            patch.Map(source => source.Id, target => target.SourceId)
-                .Map(source => $"{source.Submission?.Code ?? "BLOCKER"}-{source.Id}", target => target.Slug)
+            patch.Map(source => source.SourceId, target => target.SourceId)
+                .Map(source => source.SourceId, target => target.Slug)
                 .Map(source => (source.Submission?.Title ?? source.Description?.GetValueOrDefault(_eventOptions.DefaultLocale) ?? "").Split('–')[0]?.Trim(), target => target.Title)
                 .Map(source => ((source.Submission?.Title ?? source.Description?.GetValueOrDefault(_eventOptions.DefaultLocale) ?? "") + '–').Split('–')[1]?.Trim(), target => target.SubTitle)
                 .Map(source => source.Submission?.Abstract, target => target.Abstract)

--- a/src/Eurofurence.App.Server.Services/Events/EventService.cs
+++ b/src/Eurofurence.App.Server.Services/Events/EventService.cs
@@ -213,7 +213,12 @@ namespace Eurofurence.App.Server.Services.Events
                 // Eurofurence and thus filtered out as well.
                 // Subsequently, all slots without submission can be considered internal blockers.
                 var slots = pretalxSchedule.Slots.Where(slot => slot.Start != null && slot.End != null && slot.Submission != null).Concat(slotsBlocker);
-                var slotsPublic = slots.Where(slot => (!slot.Submission?.Tags.Contains(_eventOptions.InternalTagId)) ?? false);
+                var slotsPublic = _eventOptions.MarkAllInternal ?
+                    new HashSet<PretalxSlot>()
+                    :
+                    slots.Where(slot =>
+                        !slot.Submission?.Tags.Contains(_eventOptions.InternalTagId) ?? false
+                    ).ToHashSet();
 
                 var tracks = slots.Where(slot => slot.Submission != null).Select(slot => slot.Submission.Track).ToHashSet();
                 var tracksPublic = slotsPublic.Select(slot => slot.Submission.Track).ToHashSet();

--- a/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/EventFeedbackController.cs
@@ -60,7 +60,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         [Authorize(Roles = "Admin, EventFeedbackManager")]
         [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<EventFeedbackResponse>), 200)]
-        public ActionResult GetEventFeedback(int? eventSourceId)
+        public ActionResult GetEventFeedback(string? eventSourceId)
         {
             IEnumerable<EventFeedbackRecord> records = _eventFeedbackService.FindAll();
             if (eventSourceId != null)

--- a/src/Eurofurence.App.Server.Web/appsettings.sample.json
+++ b/src/Eurofurence.App.Server.Web/appsettings.sample.json
@@ -145,6 +145,7 @@
     "DefaultLocale": "en",
     "InternalTagId": 0,
     "InternalTrackId": 0,
+    "MarkAllInternal": true,
     "EventDays": {
       "1970-01-01": "Mon – Staff Arrival",
       "1970-01-02": "Tue – Early Arrival",

--- a/test/Eurofurence.App.Domain.Model.Tests/DtoTest/EventTests.cs
+++ b/test/Eurofurence.App.Domain.Model.Tests/DtoTest/EventTests.cs
@@ -54,7 +54,7 @@ public class EventTests
             Tags = ["Tag1", "Tag2"],
             BannerImageId = Guid.NewGuid(),
             PosterImageId = Guid.NewGuid(),
-            SourceId = 1,
+            SourceId = "ABCDEF0",
             BannerImage = new ImageRecord(),
             PosterImage = new ImageRecord(),
             ConferenceTrack = new EventConferenceTrackRecord(),


### PR DESCRIPTION
* fixes issue with event entries not being flagged as internal
* adds a configuration key to make all events internal for pre-production use
* fixes an issue where the `SourceId` of an event would change with every new schedule version caused by Pretalx:
  * allowing submissions to be referenced by more than one slot in the schedule while
  * copying all slots for each new schedule release, leading to
  * `slot.id` having a new value with each release of a new schedule version
  * making it impossible to track a slot's movements across schedule releases.