### PR TITLE
feat(sync): AppConfig section for arbitrary key value pairs

### DIFF
--- a/src/Eurofurence.App.Domain.Model/Storage/AggregatedDeltaResponse.cs
+++ b/src/Eurofurence.App.Domain.Model/Storage/AggregatedDeltaResponse.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Eurofurence.App.Domain.Model.Announcements;
 using Eurofurence.App.Domain.Model.ArtistsAlley;
 using Eurofurence.App.Domain.Model.Dealers;
@@ -28,6 +29,7 @@ namespace Eurofurence.App.Domain.Model.Sync
         public DeltaResponse<AnnouncementResponse> Announcements { get; set; }
         public DeltaResponse<MapResponse> Maps { get; set; }
         public DeltaResponse<ArtistAlleyResponse> TableRegistrations { get; set; }
+        public Dictionary<string, string> AppConfig { get; set; }
     }
 
 

--- a/src/Eurofurence.App.Server.Services/Abstractions/AppConfig/AppConfigOptions.cs
+++ b/src/Eurofurence.App.Server.Services/Abstractions/AppConfig/AppConfigOptions.cs
@@ -1,0 +1,6 @@
+﻿using System.Collections.Generic;
+
+namespace Eurofurence.App.Server.Services.Abstractions.AppConfig
+{
+    public class AppConfigOptions : Dictionary<string, string> { }
+}

--- a/src/Eurofurence.App.Server.Web/Controllers/SyncController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/SyncController.cs
@@ -3,6 +3,7 @@ using Eurofurence.App.Domain.Model.Knowledge;
 using Eurofurence.App.Domain.Model.Sync;
 using Eurofurence.App.Server.Services.Abstractions;
 using Eurofurence.App.Server.Services.Abstractions.Announcements;
+using Eurofurence.App.Server.Services.Abstractions.AppConfig;
 using Eurofurence.App.Server.Services.Abstractions.ArtistsAlley;
 using Eurofurence.App.Server.Services.Abstractions.Dealers;
 using Eurofurence.App.Server.Services.Abstractions.Events;
@@ -36,6 +37,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         private readonly IMapService _mapService;
         private readonly ITableRegistrationService _tableRegistrationService;
         private readonly GlobalOptions _globalOptions;
+        private readonly AppConfigOptions _appConfigOptions;
         private readonly IMapper _mapper;
         public SyncController(
             ILoggerFactory loggerFactory,
@@ -51,6 +53,7 @@ namespace Eurofurence.App.Server.Web.Controllers
             IMapService mapService,
             ITableRegistrationService tableRegistrationService,
             IOptions<GlobalOptions> globalOptions,
+            IOptions<AppConfigOptions> appConfigOptions,
             IMapper mapper
         )
         {
@@ -67,6 +70,7 @@ namespace Eurofurence.App.Server.Web.Controllers
             _mapService = mapService;
             _tableRegistrationService = tableRegistrationService;
             _globalOptions = globalOptions.Value;
+            _appConfigOptions = appConfigOptions.Value;
             _mapper = mapper;
         }
 
@@ -116,6 +120,7 @@ namespace Eurofurence.App.Server.Web.Controllers
                 Announcements = await _announcementService.GetDeltaResponseAsync(since),
                 Maps = await _mapService.GetDeltaResponseAsync(since),
                 TableRegistrations = tableRegistrations,
+                AppConfig = _appConfigOptions,
             };
 
             // Filter internal event-related entities for non-staff

--- a/src/Eurofurence.App.Server.Web/Program.cs
+++ b/src/Eurofurence.App.Server.Web/Program.cs
@@ -3,6 +3,7 @@ using Duende.AspNetCore.Authentication.OAuth2Introspection;
 using Eurofurence.App.Infrastructure.EntityFramework;
 using Eurofurence.App.Server.Services.Abstractions;
 using Eurofurence.App.Server.Services.Abstractions.Announcements;
+using Eurofurence.App.Server.Services.Abstractions.AppConfig;
 using Eurofurence.App.Server.Services.Abstractions.ArtistsAlley;
 using Eurofurence.App.Server.Services.Abstractions.Dealers;
 using Eurofurence.App.Server.Services.Abstractions.Events;
@@ -86,6 +87,7 @@ namespace Eurofurence.App.Server.Web
             builder.Services.Configure<MapOptions>(builder.Configuration.GetSection("Maps"));
             builder.Services.Configure<IdentityOptions>(builder.Configuration.GetSection("Identity"));
             builder.Services.Configure<AuthorizationOptions>(builder.Configuration.GetSection("Authorization"));
+            builder.Services.Configure<AppConfigOptions>(builder.Configuration.GetSection("AppConfig"));
             builder.Services.Configure<ForwardedHeadersOptions>(options =>
             {
                 options.ForwardedHeaders = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.All;

--- a/src/Eurofurence.App.Server.Web/appsettings.sample.json
+++ b/src/Eurofurence.App.Server.Web/appsettings.sample.json
@@ -176,5 +176,10 @@
   },
   "Maps": {
     "UrlTemplate": "https://nav.eurofurence.org/l/uuid-{id}/"
+  },
+  "AppConfig": {
+    "MapsUrl": "https://nav.example.com",
+    "CmaUrl": "https://catch-em-all.example.com",
+    "FeatureFoobarDisabled": true
   }
 }


### PR DESCRIPTION
Allows us to set feature flags and some other configuration values via the API instead of compiling them into the app.