### PR TITLE
fix: remove internal events filter from favorite events retrieval

### DIFF
--- a/src/Eurofurence.App.Server.Services/Events/EventService.cs
+++ b/src/Eurofurence.App.Server.Services/Events/EventService.cs
@@ -114,11 +114,6 @@ namespace Eurofurence.App.Server.Services.Events
 
             foreach (var item in favoriteEvents)
             {
-                // TODO: Check user authorisation for internal events if we wish to allow them in
-                //       favorites iCal? An issue would only arise if somebody favs internal events
-                //       and then is removed from staff, which should likely not be an issue.
-                if (item.IsInternal) continue;
-
                 // Include for each event the title, start time/end time and the description of the event including
                 // the organizer of the panel.
                 CalendarEvent calendarEvent = new CalendarEvent()


### PR DESCRIPTION
Internal events are now also included in the calendar export.

We already check if a user is staff when they try to fave an event.