### PR TITLE
fix(identity): avoid caching userinfo without name claim

### DIFF
--- a/src/Eurofurence.App.Server.Services/Identity/IdentityService.cs
+++ b/src/Eurofurence.App.Server.Services/Identity/IdentityService.cs
@@ -81,7 +81,9 @@ namespace Eurofurence.App.Server.Services.Identity
             // FIX: IDP will occasionally omit name claim on userinfo; can be fixed by retrying later.
             //      This only rarely happens (every few hundred requests) so we can simply not cache
             //      the broken response and try again next time.
-            var hasMissingNameBug = !response.Claims.Any(claim => claim.Type == "name");
+            var hasMissingNameBug = string.IsNullOrEmpty(
+                response.Claims.FirstOrDefault(claim => claim.Type == "name")?.Type
+            );
             if (hasMissingNameBug)
             {
                 _logger.LogInformation("Response to userinfo request missing 'name' claim will not be cached.");

--- a/src/Eurofurence.App.Server.Services/Identity/IdentityService.cs
+++ b/src/Eurofurence.App.Server.Services/Identity/IdentityService.cs
@@ -1,12 +1,4 @@
-﻿using Eurofurence.App.Domain.Model.Announcements;
-using Eurofurence.App.Domain.Model.PushNotifications;
-using Eurofurence.App.Domain.Model.Users;
-using Eurofurence.App.Infrastructure.EntityFramework;
-using Eurofurence.App.Server.Services.Abstractions.Identity;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
-using Microsoft.Extensions.Options;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -19,7 +11,16 @@ using System.Threading;
 using System.Threading.Tasks;
 using Duende.AspNetCore.Authentication.OAuth2Introspection;
 using Duende.IdentityModel.Client;
+using Eurofurence.App.Domain.Model.Announcements;
 using Eurofurence.App.Domain.Model.Identity;
+using Eurofurence.App.Domain.Model.PushNotifications;
+using Eurofurence.App.Domain.Model.Users;
+using Eurofurence.App.Infrastructure.EntityFramework;
+using Eurofurence.App.Server.Services.Abstractions.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Eurofurence.App.Server.Services.Identity
 {
@@ -29,6 +30,7 @@ namespace Eurofurence.App.Server.Services.Identity
         private readonly IOptionsMonitor<IdentityOptions> _identityOptionsMonitor;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IDistributedCache _cache;
+        private readonly ILogger _logger;
 
         /// <summary>
         /// The name of the claim type for IDP groups.
@@ -39,12 +41,14 @@ namespace Eurofurence.App.Server.Services.Identity
             AppDbContext appDbContext,
             IOptionsMonitor<IdentityOptions> identityOptions,
             IHttpClientFactory httpClientFactory,
-            IDistributedCache cache)
+            IDistributedCache cache,
+            ILoggerFactory loggerFactory)
         {
             _appDbContext = appDbContext;
             _identityOptionsMonitor = identityOptions;
             _httpClientFactory = httpClientFactory;
             _cache = cache;
+            _logger = loggerFactory.CreateLogger(GetType());
         }
 
         public async Task ReadUserInfo(ClaimsIdentity identity)
@@ -74,8 +78,17 @@ namespace Eurofurence.App.Server.Services.Identity
 
             identity.AddClaims(response.Claims);
 
+            // FIX: IDP will occasionally omit name claim on userinfo; can be fixed by retrying later.
+            //      This only rarely happens (every few hundred requests) so we can simply not cache
+            //      the broken response and try again next time.
+            var hasMissingNameBug = !response.Claims.Any(claim => claim.Type == "name");
+            if (hasMissingNameBug)
+            {
+                _logger.LogInformation("Response to userinfo request missing 'name' claim will not be cached.");
+            }
+
             var exp = identity.FindFirst(x => x.Type == "exp");
-            if (exp is not null && long.TryParse(exp.Value, out var seconds))
+            if (!hasMissingNameBug && exp is not null && long.TryParse(exp.Value, out var seconds))
             {
                 await _cache.SetStringAsync(
                     $"{token}_userinfo",

--- a/src/Eurofurence.App.Server.Services/Identity/IdentityService.cs
+++ b/src/Eurofurence.App.Server.Services/Identity/IdentityService.cs
@@ -82,7 +82,7 @@ namespace Eurofurence.App.Server.Services.Identity
             //      This only rarely happens (every few hundred requests) so we can simply not cache
             //      the broken response and try again next time.
             var hasMissingNameBug = string.IsNullOrEmpty(
-                response.Claims.FirstOrDefault(claim => claim.Type == "name")?.Type
+                response.Claims.FirstOrDefault(claim => claim.Type == "name")?.Value
             );
             if (hasMissingNameBug)
             {

--- a/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
@@ -153,6 +153,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         [HttpGet("Pass/:token")]
         [ProducesResponseType(typeof(string), 200)]
         [ProducesResponseType(typeof(string), 404)]
+        [ProducesResponseType(typeof(string), 400)]
         [Authorize(Roles = IdentityRoles.Attendee)]
         public async Task<ActionResult> GetPassToken()
         {

--- a/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/UsersController.cs
@@ -166,6 +166,11 @@ namespace Eurofurence.App.Server.Web.Controllers
                 return Unauthorized();
             }
 
+            if (string.IsNullOrEmpty(identity.Name))
+            {
+                return BadRequest("Malformed authentication.");
+            }
+
             var claims = new Dictionary<string, string>
             {
                 // Required for obtaining registration data in <c>GetPass()</c>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of incomplete authentication information.
  - Malformed authentication now returns a clear error instead of creating a pass token.
  - Invalid user information is excluded from caching to prevent reuse of incomplete data.
  - Added logging to help diagnose authentication data issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->