### PR TITLE
fix(events): strip Markdown embeds and HTML

### DIFF
--- a/src/Eurofurence.App.Server.Services/Events/EventService.cs
+++ b/src/Eurofurence.App.Server.Services/Events/EventService.cs
@@ -43,7 +43,8 @@ namespace Eurofurence.App.Server.Services.Events
         private readonly AppDbContext _appDbContext;
         private readonly IDistributedCache _cache;
         private readonly IHtmlSanitizer _htmlSanitizer;
-        private readonly Regex _markdownEmbed = new(@"\!\[[^\]]*\]\([^)]*\)");
+        private readonly Regex _markdownImageEmbed = new(@"\!\[([^\]]|\\\])*\]\(([^\)]|\\\))*\)");
+        private readonly Regex _markdownImageReference = new(@"\!\[([^\]]|\\\])*\]\[([^\]]|\\\])*\]");
 
         private static readonly SemaphoreSlim Semaphore = new(1, 1);
 
@@ -431,7 +432,11 @@ namespace Eurofurence.App.Server.Services.Events
         {
             if (string.IsNullOrEmpty(input)) return input;
 
-            return _markdownEmbed.Replace(_htmlSanitizer.Sanitize(input), "");
+            var sanitizedInput = _htmlSanitizer.Sanitize(input);
+            sanitizedInput = _markdownImageEmbed.Replace(sanitizedInput, "");
+            sanitizedInput = _markdownImageReference.Replace(sanitizedInput, "");
+
+            return sanitizedInput;
         }
     }
 }

--- a/src/Eurofurence.App.Server.Services/Events/EventService.cs
+++ b/src/Eurofurence.App.Server.Services/Events/EventService.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Security.Claims;
 using System.Security.Cryptography;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using AngleSharp.Common;
@@ -17,6 +18,7 @@ using Eurofurence.App.Domain.Model.PushNotifications;
 using Eurofurence.App.Infrastructure.EntityFramework;
 using Eurofurence.App.Server.Services.Abstractions;
 using Eurofurence.App.Server.Services.Abstractions.Events;
+using Eurofurence.App.Server.Services.Abstractions.Sanitization;
 using Eurofurence.App.Server.Services.Abstractions.Security;
 using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
@@ -40,6 +42,8 @@ namespace Eurofurence.App.Server.Services.Events
         private readonly EventOptions _eventOptions;
         private readonly AppDbContext _appDbContext;
         private readonly IDistributedCache _cache;
+        private readonly IHtmlSanitizer _htmlSanitizer;
+        private readonly Regex _markdownEmbed = new(@"\!\[[^\]]*\]\([^)]*\)");
 
         private static readonly SemaphoreSlim Semaphore = new(1, 1);
 
@@ -59,7 +63,8 @@ namespace Eurofurence.App.Server.Services.Events
             IEventFavoriteStatisticsService eventFavoriteStatisticsService,
             ILoggerFactory loggerFactory,
             IOptions<EventOptions> eventOptions,
-            IDistributedCache cache
+            IDistributedCache cache,
+            IHtmlSanitizer htmlSanitizer
         )
             : base(appDbContext, storageServiceFactory)
         {
@@ -72,6 +77,7 @@ namespace Eurofurence.App.Server.Services.Events
             DateTimeOffset = TimeSpan.Zero;
             _logger = loggerFactory.CreateLogger(GetType());
             _cache = cache;
+            _htmlSanitizer = htmlSanitizer;
         }
 
 
@@ -391,10 +397,10 @@ namespace Eurofurence.App.Server.Services.Events
             // Public breaks have no submission; their title can be found in the slot description.
             patch.Map(source => source.SourceId, target => target.SourceId)
                 .Map(source => source.Submission?.Code ?? source.SourceId?.Split('-')[0] ?? "UNKNWN", target => target.Slug)
-                .Map(source => (source.Submission?.Title ?? source.Description?.GetValueOrDefault(_eventOptions.DefaultLocale) ?? "").Split('–')[0]?.Trim(), target => target.Title)
-                .Map(source => ((source.Submission?.Title ?? source.Description?.GetValueOrDefault(_eventOptions.DefaultLocale) ?? "") + '–').Split('–')[1]?.Trim(), target => target.SubTitle)
-                .Map(source => source.Submission?.Abstract, target => target.Abstract)
-                .Map(source => source.Submission?.Description ?? source.Description?.GetValueOrDefault(_eventOptions.DefaultLocale) ?? "", target => target.Description)
+                .Map(source => SanitizeUserInput(source.Submission?.Title ?? source.Description?.GetValueOrDefault(_eventOptions.DefaultLocale) ?? "").Split('–')[0]?.Trim(), target => target.Title)
+                .Map(source => SanitizeUserInput((source.Submission?.Title ?? source.Description?.GetValueOrDefault(_eventOptions.DefaultLocale) ?? "") + '–').Split('–')[1]?.Trim(), target => target.SubTitle)
+                .Map(source => SanitizeUserInput(source.Submission?.Abstract), target => target.Abstract)
+                .Map(source => SanitizeUserInput(source.Submission?.Description ?? source.Description?.GetValueOrDefault(_eventOptions.DefaultLocale) ?? ""), target => target.Description)
                 .Map(
                     source => currentConferenceTracks.SingleOrDefault(track => track.SourceId == (source.Submission?.Track.Id ?? _eventOptions.InternalTrackId)).Id,
                     target => target.ConferenceTrackId)
@@ -419,6 +425,13 @@ namespace Eurofurence.App.Server.Services.Events
 
             var modifiedRecords = diff.Count(a => a.Action != ActionEnum.NotModified);
             return new Tuple<int, List<EventRecord>>(modifiedRecords, [.. diff.Where(a => a.Entity.IsDeleted == 0).Select(a => a.Entity)]);
+        }
+
+        private string SanitizeUserInput(string input)
+        {
+            if (string.IsNullOrEmpty(input)) return input;
+
+            return _markdownEmbed.Replace(_htmlSanitizer.Sanitize(input), "");
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the safety of imported event content by removing potentially unsafe HTML.
  * Removed embedded Markdown images from event titles, subtitles, abstracts, and descriptions.
  * Cleaned imported event content for more consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->