### PR TITLE
feat(web): support /Events/[id]/Feedback route & render soft as hard line breaks

### DIFF
--- a/src/Eurofurence.App.Server.Web/Controllers/WebPreviewController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/WebPreviewController.cs
@@ -71,8 +71,14 @@ namespace Eurofurence.App.Server.Web.Controllers
             ViewData[VIEWDATA_APPID_PLAY] = _globalOptions.AppIdPlay;
         }
 
+        [HttpGet("Events/{id}/Feedback")]
+        public async Task<ActionResult> GetEventByIdWithFeedback(Guid id)
+        {
+            return await GetEventById(id, true);
+        }
+
         [HttpGet("Events/{id}")]
-        public async Task<ActionResult> GetEventById(Guid id)
+        public async Task<ActionResult> GetEventById(Guid id, bool tryFeedback = false)
         {
             var @event = await _eventService.FindAll(e => !e.IsInternal).Include(e => e.BannerImage).Include(e => e.PosterImage).FirstOrDefaultAsync(e => e.Id == id);
             if (@event == null) return NotFound();
@@ -92,6 +98,8 @@ namespace Eurofurence.App.Server.Web.Controllers
             ViewData["eventConferenceTrack"] = eventConferenceTrack;
             ViewData["eventStartDateTime"] = eventStartDateTime;
             ViewData["eventEndDateTime"] = eventEndDateTime;
+
+            ViewData["tryFeedback"] = tryFeedback;
 
             ViewData["markdownPipeline"] = _markdownPipeline;
 

--- a/src/Eurofurence.App.Server.Web/Controllers/WebPreviewController.cs
+++ b/src/Eurofurence.App.Server.Web/Controllers/WebPreviewController.cs
@@ -1,15 +1,16 @@
-﻿using Eurofurence.App.Domain.Model.Maps;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Eurofurence.App.Domain.Model.Maps;
 using Eurofurence.App.Server.Services.Abstractions;
 using Eurofurence.App.Server.Services.Abstractions.Dealers;
 using Eurofurence.App.Server.Services.Abstractions.Events;
 using Eurofurence.App.Server.Services.Abstractions.Knowledge;
 using Eurofurence.App.Server.Services.Abstractions.Maps;
 using Eurofurence.App.Server.Web.Extensions;
+using Markdig;
 using Microsoft.AspNetCore.Mvc;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
@@ -27,6 +28,7 @@ namespace Eurofurence.App.Server.Web.Controllers
         private readonly IKnowledgeGroupService _knowledgeGroupService;
         private readonly IKnowledgeEntryService _knowledgeEntryService;
         private readonly IMapService _mapService;
+        private readonly MarkdownPipeline _markdownPipeline;
 
         public const string VIEWDATA_OPENGRAPH_METADATA = nameof(OpenGraphMetadata);
         public const string VIEWDATA_APPID_ITUNES = nameof(GlobalOptions.AppIdITunes);
@@ -56,6 +58,7 @@ namespace Eurofurence.App.Server.Web.Controllers
             _knowledgeGroupService = knowledgeGroupService;
             _knowledgeEntryService = knowledgeEntryService;
             _mapService = mapService;
+            _markdownPipeline = new MarkdownPipelineBuilder().UseSoftlineBreakAsHardlineBreak().Build();
         }
 
         private void PopulateViewData()
@@ -89,6 +92,8 @@ namespace Eurofurence.App.Server.Web.Controllers
             ViewData["eventConferenceTrack"] = eventConferenceTrack;
             ViewData["eventStartDateTime"] = eventStartDateTime;
             ViewData["eventEndDateTime"] = eventEndDateTime;
+
+            ViewData["markdownPipeline"] = _markdownPipeline;
 
             ViewData[VIEWDATA_OPENGRAPH_METADATA] = new OpenGraphMetadata()
                 .WithTitle(@event.Title)

--- a/src/Eurofurence.App.Server.Web/Views/WebPreview/EventPreview.cshtml
+++ b/src/Eurofurence.App.Server.Web/Views/WebPreview/EventPreview.cshtml
@@ -16,6 +16,7 @@
     var eventConferenceTrack = (ViewData["eventConferenceTrack"] as EventConferenceTrackRecord);
     var eventStartDateTime = (ViewData["eventStartDateTime"] as DateTime?);
     var eventEndDateTime = (ViewData["eventEndDateTime"] as DateTime?);
+    var tryFeedback = ViewData["tryFeedback"] as bool?;
 
     var title = Model.Title;
     var subTitle = Model.SubTitle;
@@ -45,6 +46,13 @@
     <div class="infobox"><label><i class="fas fa-clock"></i>From:</label> @eventStartDateTime?.ToString("HH\\:mm")</div>
     <div class="infobox"><label><i class="fas fa-step-forward"></i>To:</label> @eventEndDateTime?.ToString("HH\\:mm")</div>
     <div class="infobox"><label><i class="fas fa-map-marker-alt"></i>Where:</label> @eventConferenceRoom.Name</div>
+
+    @if (tryFeedback ?? false)
+    {
+        <div class="infobox warning">
+            <i class="fas fa-warning"></i> Please note that giving feedback on events is only possible via the app.
+        </div>
+    }
 </section>
 
 <section class="row">

--- a/src/Eurofurence.App.Server.Web/Views/WebPreview/EventPreview.cshtml
+++ b/src/Eurofurence.App.Server.Web/Views/WebPreview/EventPreview.cshtml
@@ -1,9 +1,11 @@
 ﻿@using Eurofurence.App.Domain.Model.Events
 @using Eurofurence.App.Server.Web.Controllers
+@using Markdig
 @model EventRecord
 
 @{
     Layout = "~/Views/Shared/_WebPreviewLayout.cshtml";
+    var markdownPipeline = ViewData["markdownPipeline"] as MarkdownPipeline;
 
     var apiBaseUrl = ViewData[WebPreviewController.VIEWDATA_API_BASE_URL] as string;
     var webBaseUrl = ViewData[WebPreviewController.VIEWDATA_WEB_BASE_URL] as string;
@@ -34,7 +36,7 @@
 
     @if (showAbstract)
     {
-        @Html.Raw(Markdig.Markdown.ToHtml(Model.Abstract))
+        @Html.Raw(Markdig.Markdown.ToHtml(Model.Abstract, markdownPipeline))
     }
 </header>
 
@@ -47,7 +49,7 @@
 
 <section class="row">
     <div class="@(Model.PosterImage != null ? "one-half" : "three") column">
-        @Html.Raw(Markdig.Markdown.ToHtml(Model.Description))
+        @Html.Raw(Markdig.Markdown.ToHtml(Model.Description, markdownPipeline))
     </div>
 
     @if (Model.PosterImage != null)

--- a/src/Eurofurence.App.Server.Web/wwwroot/css/webpreview.css
+++ b/src/Eurofurence.App.Server.Web/wwwroot/css/webpreview.css
@@ -79,6 +79,11 @@ section.nomargin>* {
     margin-bottom: 0.70em;
 }
 
+.infobox.warning {
+    background: #fefecc;
+    border-color: #aaaa55;
+}
+
 .infobox>label {
     margin: 0;
     white-space: nowrap;


### PR DESCRIPTION
Pretalx renders simple newlines as line breaks (`nl2br`) and we should do the same to keep things consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown rendering in event previews.
  * Soft line breaks are now displayed as visible line breaks, preserving the formatting of event abstracts and descriptions.
  * Event preview content now renders more consistently across supported Markdown formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->