### PR TITLE
fix(push): catch exceptions with APNs

### DIFF
--- a/src/Eurofurence.App.Server.Services/PushNotifications/PushNotificationChannelManager.cs
+++ b/src/Eurofurence.App.Server.Services/PushNotifications/PushNotificationChannelManager.cs
@@ -350,7 +350,8 @@ namespace Eurofurence.App.Server.Services.PushNotifications
             var invalidDeviceIdentityIds = new List<Guid>();
             foreach (var apnsResult in apnsResults)
             {
-                if (apnsResult.ApnsResponse.IsSuccessful) continue;
+                // No pruning needed for successful requests or those that failed with an exception.
+                if (apnsResult.ApnsResponse?.IsSuccessful ?? true) continue;
 
                 var responseReason = apnsResult.ApnsResponse.Reason;
                 if (responseReason == ApnsResponseReason.BadDeviceToken
@@ -485,10 +486,20 @@ namespace Eurofurence.App.Server.Services.PushNotifications
                 TeamId = _apnsOptions.TeamId,
             };
 
+            ApnsResponse apnsResponse = null;
+            try
+            {
+                apnsResponse = await _apnsService.SendPush(applePush, apnsJwtOptions);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to send APNs push to {deviceIdentity} for type {pushEventType} with related ID {relatedId}", deviceIdentity, eventType, relatedId);
+            }
+
             return new ApnsResult()
             {
                 DeviceIdentity = deviceIdentity,
-                ApnsResponse = await _apnsService.SendPush(applePush, apnsJwtOptions)
+                ApnsResponse = apnsResponse
             };
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push notification handling when Apple Push Notification Service responses are missing.
  * Prevented notification delivery errors from causing application failures.
  * Failed notification attempts are now logged for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->