### PR TITLE
fix: sort announcements backoffice

### DIFF
--- a/src/Eurofurence.App.Backoffice/Pages/Announcements.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/Announcements.razor
@@ -14,7 +14,7 @@
     <MudSpacer />
 </MudToolBar>
 
-<MudDataGrid T="AnnouncementResponse" Items="_items" Filterable="true"
+<MudDataGrid T="AnnouncementResponse" @ref="_dataGrid" Items="_items" Filterable="true"
     FilterMode="@DataGridFilterMode.ColumnFilterMenu">
     <Columns>
         <PropertyColumn Title="Title" Property="arg => arg.Title"></PropertyColumn>
@@ -36,11 +36,13 @@
 </MudDataGrid>
 
 @code {
+    
+    private MudDataGrid<AnnouncementResponse> _dataGrid = null!;
+    
     /// <summary>
     /// A collection of the loaded announcements to display in the data grid.
     /// </summary>
     private IEnumerable<AnnouncementResponse> _items = new List<AnnouncementResponse>();
-
     private async Task OnClickDelete(AnnouncementResponse contextItem)
     {
         DialogParameters<ConfirmDialog> dialogUserban = new()
@@ -106,6 +108,11 @@
                 Snackbar.Add($"Error loading announcements: {ex.Message}", Severity.Error);
             }
         }
+    }
+
+    protected override async void OnAfterRender(bool firstRender)
+    {
+        _dataGrid?.SetSortAsync(nameof(AnnouncementRecord.ValidFromDateTimeUtc), SortDirection.Descending, x => x.ValidFromDateTimeUtc);
     }
 
     /// <summary>

--- a/src/Eurofurence.App.Backoffice/Pages/Announcements.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/Announcements.razor
@@ -111,7 +111,7 @@
             }
         }
     }
-    
+
     /// <summary>
     /// Called after the component has rendered.
     /// Will load the announcements from the service if this is the first render.

--- a/src/Eurofurence.App.Backoffice/Pages/Announcements.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/Announcements.razor
@@ -24,7 +24,6 @@
         <PropertyColumn Title="ValidFromDateTimeUtc" Property="arg => arg.ValidFromDateTimeUtc"></PropertyColumn>
         <PropertyColumn Title="ValidUntilDateTimeUtc" Property="arg => arg.ValidUntilDateTimeUtc"></PropertyColumn>
         <PropertyColumn Title="LastChangeDateTimeUtc" Property="arg => arg.LastChangeDateTimeUtc"></PropertyColumn>
-
         <TemplateColumn>
             <CellTemplate>
                 <MudIconButton Icon="@Icons.Material.Filled.Edit" OnClick="@(() => OnClickEdit(context.Item))" />

--- a/src/Eurofurence.App.Backoffice/Pages/Announcements.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/Announcements.razor
@@ -113,7 +113,7 @@
 
     protected override async void OnAfterRender(bool firstRender)
     {
-        _dataGrid?.SetSortAsync(nameof(AnnouncementRecord.ValidFromDateTimeUtc), SortDirection.Descending, x => x.ValidFromDateTimeUtc);
+        _dataGrid?.SetSortAsync(nameof(AnnouncementResponse.ValidFromDateTimeUtc), SortDirection.Descending, x => x.ValidFromDateTimeUtc);
     }
 
     /// <summary>

--- a/src/Eurofurence.App.Backoffice/Pages/Announcements.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/Announcements.razor
@@ -44,6 +44,7 @@
     /// A collection of the loaded announcements to display in the data grid.
     /// </summary>
     private IEnumerable<AnnouncementResponse> _items = new List<AnnouncementResponse>();
+    
     private async Task OnClickDelete(AnnouncementResponse contextItem)
     {
         DialogParameters<ConfirmDialog> dialogUserban = new()

--- a/src/Eurofurence.App.Backoffice/Pages/Announcements.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/Announcements.razor
@@ -23,6 +23,8 @@
         <PropertyColumn Title="Content" Property="arg => arg.Content"></PropertyColumn>
         <PropertyColumn Title="ValidFromDateTimeUtc" Property="arg => arg.ValidFromDateTimeUtc"></PropertyColumn>
         <PropertyColumn Title="ValidUntilDateTimeUtc" Property="arg => arg.ValidUntilDateTimeUtc"></PropertyColumn>
+        <PropertyColumn Title="LastChangeDateTimeUtc" Property="arg => arg.LastChangeDateTimeUtc"></PropertyColumn>
+
         <TemplateColumn>
             <CellTemplate>
                 <MudIconButton Icon="@Icons.Material.Filled.Edit" OnClick="@(() => OnClickEdit(context.Item))" />

--- a/src/Eurofurence.App.Backoffice/Pages/Announcements.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/Announcements.razor
@@ -44,7 +44,7 @@
     /// A collection of the loaded announcements to display in the data grid.
     /// </summary>
     private IEnumerable<AnnouncementResponse> _items = new List<AnnouncementResponse>();
-    
+
     private async Task OnClickDelete(AnnouncementResponse contextItem)
     {
         DialogParameters<ConfirmDialog> dialogUserban = new()

--- a/src/Eurofurence.App.Backoffice/Pages/Announcements.razor
+++ b/src/Eurofurence.App.Backoffice/Pages/Announcements.razor
@@ -110,12 +110,7 @@
             }
         }
     }
-
-    protected override async void OnAfterRender(bool firstRender)
-    {
-        _dataGrid?.SetSortAsync(nameof(AnnouncementResponse.ValidFromDateTimeUtc), SortDirection.Descending, x => x.ValidFromDateTimeUtc);
-    }
-
+    
     /// <summary>
     /// Called after the component has rendered.
     /// Will load the announcements from the service if this is the first render.
@@ -128,6 +123,7 @@
         if (firstRender)
         {
             await LoadAnnouncementsAsync();
+            await _dataGrid.SetSortAsync(nameof(AnnouncementResponse.ValidFromDateTimeUtc), SortDirection.Descending, x => x.ValidFromDateTimeUtc);
         }
     }
     


### PR DESCRIPTION
Sort announcements by ValidFromDateTimeUtc by default.

Also adding LastChangeDateTimeUtc to the table.